### PR TITLE
Trivial documentation patch

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -690,7 +690,7 @@ App::perlbrew - Manage perl installations in your $HOME
     perlbrew install perl-5.13.5
 
     # See what were installed
-    perlbrew installed
+    perlbrew list
 
     # Switch perl in the $PATH
     perlbrew switch perl-5.12.2


### PR DESCRIPTION
Updated SYNOPSIS using "list" instead of deprecated "installed". Otherwise, the docs suggest things that trigger the warning about the deprecated feature.
