### PR TITLE
treat /bin/sh as a non-csh shell

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -671,7 +671,7 @@ sub run_command_env {
 
     my %env = $self->perlbrew_env($perl);
 
-    if ($self->env('SHELL') =~ /(ba|z)sh$/) {
+    if ($self->env('SHELL') =~ /(ba|z|\/)sh$/) {
         while (my ($k, $v) = each(%env)) {
             print "export $k=$v\n";
         }


### PR DESCRIPTION
When using perlbrew in cron jobs (which default to using /bin/sh), it gets confused and rewrites ~/.perlbrew/init using csh syntax, since the shell isn't bash or zsh.
