### PR TITLE
Use Devel::PatchPerl to make old perls build

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+- Automatically apply patches necessary to make older perls build again on
+  modern platforms with the help of Devel::PatchPerl.
+
 0.18:
 - Spotted and fixed by chad.a.davis++, an issue when bash set "noclobber" option,
   which breaks the creation of ~/.perlbrew/init. See https://rt.cpan.org/Ticket/Display.html?id=66518

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,8 @@ all_from 'lib/App/perlbrew.pm';
 
 repository 'git://github.com/gugod/App-perlbrew.git';
 
+requires 'Devel::PatchPerl' => '0.26';
+
 test_requires 'Test::Simple';
 
 install_script 'bin/perlbrew';

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -511,6 +511,7 @@ INSTALL
             $extract_command,
             "cd $dist_extracted_dir",
             "rm -f config.sh Policy.sh",
+            "patchperl",
             "sh Configure $configure_flags " .
                 join( ' ',
                     ( map { qq{'-D$_'} } @d_options ),


### PR DESCRIPTION
Old perl releases have the tendency to not build anymore on modern platforms and require some patches for things to work again. Devel::PatchPerl provides those, as well as a little commandline helper to conveniently apply them. Use it.
