### PR TITLE
add per-project perl version

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -20,6 +20,20 @@ if [[ -f $HOME/.perlbrew/init ]]; then
     source $HOME/.perlbrew/init
 fi
 
+cd() {
+    builtin cd "$@"
+    local result=$?
+    __perlbrew_project_perlbrew
+    return $result
+}
+
+__perlbrew_project_perlbrew() {
+    local project_dir=$PWD
+    if [[ -f "$project_dir/.perlbrewrc" ]] ; then
+        source $project_dir/.perlbrewrc
+    fi
+}
+
 short_option=""
 
 __perlbrew_reinit () {
@@ -887,6 +901,11 @@ App::perlbrew - Manage perl installations in your $HOME
 
     # Exec something with all perlbrew-ed perls
     perlbrew exec perl -E 'say $]'
+
+    # To switch to a specific version for a given project whenever you
+    # enter the directory
+    cd ~/code/App-Perlbrew
+    echo "perlbrew switch perl-5.12.3" > .perlbrewrc
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Hi

I've started to work on a simple feature (inspired from rvm) where you can stick a .perlbrewrc file a directory. Simple usage:

```
cd ~/code/App-Perlbrew
echo "perlbrew switch perl-5.12.3" > .perlbrewrc
```

then next time you go to ~/code/App-Perlbrew, perl is set to version 5.12.3

There is a lot of things to do before I can consider this "done", but before spending time on this, is this a feature you would consider ?

thanks!
