### PR TITLE
Don't append '/bin' suffix when setting PERLBREW_ROOT 

### DIFF
--- a/perlbrew-install
+++ b/perlbrew-install
@@ -16,7 +16,7 @@ chmod +x perlbrew
 
 echo "## Installing patchperl"
 if [ "X${PERLBREW_ROOT}" == "X" ]; then
-    PERLBREW_ROOT="${HOME}/perl5/perlbrew/bin"
+    PERLBREW_ROOT="${HOME}/perl5/perlbrew"
 fi
 chmod +x patchperl
 cp patchperl "${PERLBREW_ROOT}/bin"


### PR DESCRIPTION
When running without a current perlbrew environment
PERLBREW_ROOT gets set to a default but with a mistake.
Since PERLBREW_ROOT had the /bin at the end,
the "cp" line copied patchperl to ~/perl5/perlbrew/bin/bin
instead of ~/perl5/perlbrew/bin/patchperl.
