### PR TITLE
Assume 5.12.3 means perl-5.12.3?

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -318,6 +318,17 @@ sub run_command {
     }
 
     die "Unknown command: `$x`. Typo?\n" unless $s;
+
+    # Assume 5.12.3 means perl-5.12.3, for example.
+    if ($x =~ /\A(?:switch|use|install)\Z/ and my $dist = shift @args) {
+        if ($dist =~ /\A(?:\d+\.)*\d+\Z/) {
+            unshift @args, "perl-$dist";
+        }
+        else {
+            unshift @args, $dist;
+        }
+    }
+
     $self->$s(@args);
 }
 
@@ -616,7 +627,7 @@ sub run_command_install {
         return
     }
 
-    my $help_message = "Unknown installation target \"$dist\", abort.\nPlease see `perlbrew help` for the insturction of install command.\n\n";
+    my $help_message = "Unknown installation target \"$dist\", abort.\nPlease see `perlbrew help` for the instruction of install command.\n\n";
 
     my ($dist_name, $dist_version) = $dist =~ m/^(.*)-([\d.]+(?:-RC\d+)?|git)$/;
     if (!$dist_name || !$dist_version) { # some kind of special install


### PR DESCRIPTION
I noticed pythonbrew lets you leave off the Python and just write 3.2 for Python-3.2. This seemed useful, so I thought perlbrew could do the same. I prepend "perl-" when just a version number is given and the command is switch, use or install.
