### PR TITLE
Added support for install from local archive

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -84,7 +84,8 @@ Build and install from the given git checkout dir.
 
 =item B<install> http://example.com/mirror/perl-5.12.3.tar.gz
 
-Build and install from the given URL.
+Build and install from the given URL. Supported URL schemes are C<http://>,
+C<https://>, C<ftp://> and C<file://>.
 
 =item B<mirror>
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -494,19 +494,27 @@ sub do_install_url {
     my $dist_tarball_url  = $dist;
     $dist = "$dist_name-$dist_version"; # we install it as this name later
 
-    print "Fetching $dist as $dist_tarball_path\n";
-    http_get(
-        $dist_tarball_url,
-        undef,
-        sub {
-            my ($body) = @_;
-            open my $BALL, "> $dist_tarball_path" or die "Couldn't open $dist_tarball_path: $!";
-            print $BALL $body;
-            close $BALL;
-        }
-    );
+    if ($dist_tarball_url =~ m/^file/) {
+        print "Installing $dist from local archive $dist_tarball_url\n";
+        $dist_tarball_url =~ s/^file:\/+/\//;
+        $dist_tarball_path = $dist_tarball_url;
+    }
+    else {
+        print "Fetching $dist as $dist_tarball_path\n";
+        http_get(
+            $dist_tarball_url,
+            undef,
+            sub {
+                my ($body) = @_;
+                open my $BALL, "> $dist_tarball_path" or die "Couldn't open $dist_tarball_path: $!";
+                print $BALL $body;
+                close $BALL;
+            }
+        );
+    }
+
     my $dist_extracted_path = $self->do_extract_tarball($dist_tarball_path);
-    $self->do_install_this($dist_extracted_path, $dist);
+    $self->do_install_this($dist_extracted_path, $dist_version, $dist);
     return;
 }
 
@@ -623,7 +631,7 @@ sub run_command_install {
         if (-d "$dist/.git") {
             $self->do_install_git($dist);
         }
-        elsif ($dist =~ m/^(?:https?|ftp)/) { # more protocols needed?
+        elsif ($dist =~ m/^(?:https?|ftp|file)/) { # more protocols needed?
             $self->do_install_url($dist);
         }
         elsif ($dist =~ m/(?:perl-)?blead$/) {


### PR DESCRIPTION
I happend to be in a situation with no Internet access but with the archive of perl-5.14.0 saved locally and i wanted to install it with perlbrew. This commit adds support for that.

It also fixes running "make test_harness" when installing from a URL.

Thank You for perlbrew!
