### PR TITLE
Fix curl auto-detection

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+$NEXT
+- Fix auto-detection of curl
+
 0.22:
 - Fix ccache support on Linux with bash.. GH #87.
 - `install` command no longer clobbers existing installations.

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -195,7 +195,8 @@ sub uniq(@) {
             );
             for my $command (@commands) {
                 my $program = $command->[0];
-                if (! system("$program --version >/dev/null 2>&1")) {
+                my $code = system("$program --version >/dev/null 2>&1") >> 8;
+                if ($code != 127) {
                     @command = @$command;
                     last;
                 }


### PR DESCRIPTION
The code assumed that $command --version always returns 0, but curl
doesn't (tested with the versions below), it returns 2.

The test was changed to check for 127, the exit code returned when
the command is not found.

$ curl --version; echo $?
curl 7.16.4 (i386-apple-darwin9.0) libcurl/7.16.4 OpenSSL/0.9.7l zlib/1.2.3
Protocols: tftp ftp telnet dict ldap http file https ftps
Features: GSS-Negotiate IPv6 Largefile NTLM SSL libz
2

$ curl --version; echo $?
curl 7.15.5 (x86_64-redhat-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8b zlib/1.2.3 libidn/0.6.5
Protocols: tftp ftp telnet dict ldap http file https ftps
Features: GSS-Negotiate IDN IPv6 Largefile NTLM SSL libz
2

curl 7.12.1 (i686-redhat-linux-gnu) libcurl/7.12.1 OpenSSL/0.9.7a zlib/1.2.1.2 libidn/0.5.6
Protocols: ftp gopher telnet dict ldap http file https ftps
Features: GSS-Negotiate IDN IPv6 Largefile NTLM SSL libz
2

$ curl --version; echo $?
curl 7.15.5 (i686-redhat-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8b zlib/1.2.3 libidn/0.6.5
Protocols: tftp ftp telnet dict ldap http file https ftps
Features: GSS-Negotiate IDN IPv6 Largefile NTLM SSL libz
2

Signed-off-by: Pedro Melo melo@simplicidade.org
