### PR TITLE
Fix missing test_requires for IO::All and Try::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -57,6 +57,7 @@ test_requires 'Test::Output';
 test_requires 'Test::Exception';
 test_requires 'Path::Class';
 test_requires 'IO::All';
+test_requires 'Try::Tiny';
 
 install_script 'bin/perlbrew';
 


### PR DESCRIPTION
The file `t/installation.t` uses `IO::All` and `Try::Tiny`, which are not listed as `test_requires` in `Makefile.PL`.

Cheers
