### PR TITLE
Add --insecure to curl check so 'perlbrew install-cpanm' works on old machines

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -195,7 +195,7 @@ sub uniq(@) {
         if (! @command) {
             my @commands = (
                 # curl's --fail option makes the exit code meaningful
-                [qw( curl --silent --location --fail )],
+                [qw( curl --insecure --silent --location --fail )],
                 [qw( wget --no-check-certificate --quiet -O - )],
             );
             for my $command (@commands) {


### PR DESCRIPTION
Add --insecure to curl check so 'perlbrew install-cpanm' works on machines with old certs, matching the wget command.
