### PR TITLE
A suggested way to prevent unalias from failing on UBUNTU

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -38,7 +38,7 @@ __perlbrew_reinit () {
 
 __perlbrew_set_path () {
     [[ -z "$PERLBREW_ROOT" ]] && return 1
-    unalias perl 2>/dev/null
+    [[ -n $(alias perl 2>/dev/null) ]] && unalias perl 2>/dev/null
     export PATH_WITHOUT_PERLBREW=$(perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_ROOT}) } split/:/,$ENV{PATH};')
     export PATH=$PERLBREW_PATH:$PATH_WITHOUT_PERLBREW
 }


### PR DESCRIPTION
'unalias' seems to fail on my Ubuntu, a similar patch was suggested here:
https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/305346
