### PR TITLE
Don't s/// the non-existent arg for 'install' command

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -454,7 +454,9 @@ sub run_command {
         }
     }
     elsif ($x eq 'install') {
-        $args[0] =~ s/\A((?:\d+\.)*\d+)\Z/perl-$1/;
+        # prepend "perl-" to version number, but only if there is an argument
+        $args[0] =~ s/\A((?:\d+\.)*\d+)\Z/perl-$1/
+            if @args;
     }
 
     $self->$s(@args);


### PR DESCRIPTION
The install command has a no-argument variant
in which case there's no string on which to perform substitution
(which generates a warning during installation).
