### PR TITLE
Add "available" command to -h screen

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -122,6 +122,10 @@ using any perlbrew-based perl.
 
 Without a parameter, shows the version of perl currently in use.
 
+=item B<available>
+
+Displays the available versions of perl on CPAN.
+
 
 =item B<switch> [perl-<version>]
 


### PR DESCRIPTION
A tiny patch to the help screen.
The available command was in the resume on the top of the page and not in the detailed output.
