### PR TITLE
Changed script to show 'switched' to version of Perl or 'off'

### DIFF
--- a/perlbrew
+++ b/perlbrew
@@ -99,11 +99,12 @@ perlbrew () {
                       exit_status=1
                   fi
               else
-                if [[ -z "$PERLBREW_PERL" ]] ; then
-                    echo "No version in use; defaulting to system"
+                if [[ -s ~/.perlbrew/init && $(grep PERLBREW_PERL ~/.perlbrew/init) ]] ; then
+                    current="to $(grep PERLBREW_PERL ~/.perlbrew/init | awk '{split($2,PERLBREW,"="); print PERLBREW[2]}')"
                 else
-                    echo "Using $PERLBREW_PERL version"
+                    current="off"
                 fi
+                echo 'Currently switched' $current;
               fi
               ;;
 


### PR DESCRIPTION
  I changed the 'switch' case in the bash portion of the script to reflect the same information provided in the perl code; 'switch' will now show the 'switched to' version of Perl or 'off'. 

I tested it out and it seems to work correctly. 

```
$ perlbrew switch
Currently switched to perl-5.14.1

$ perlbrew use perl-5.12.4

$ perlbrew switch
Currently switched to perl-5.14.1

$ perlbrew off

$ exec /bin/bash

$ perlbrew switch
Currently switched off
```
