### PR TITLE
Fixed issue #108

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1034,6 +1034,16 @@ sub run_command_use {
     my $self = shift;
     my $perl = shift;
 
+    if ( !$perl ) {
+        my $current = $self->current_perl;
+        if ($current) {
+            print "Currently using $current\n";
+        } else {
+            print "No version in use; defaulting to system\n";
+        }
+        return;
+    }
+
     my $shell = $self->env('SHELL');
     my %env = ($self->perlbrew_env($perl), PERLBREW_SKIP_INIT => 1);
 


### PR DESCRIPTION
Fixed issue #108; the 'use' command by itself will display the version of perl being used.

```
$ perlbrew use
No version in use; defaulting to system

$ command perlbrew use
No version in use; defaulting to system

$ perlbrew switch perl-5.12.4

$ perlbrew use
Using perl-5.12.4 version

$ command perlbrew use
Currently using perl-5.12.4

$ command perlbrew use perl-5.14.1

A sub-shell is launched with perl-5.14.1 as the activated perl. Run 'exit' to finish it.
```
