### PR TITLE
Respect -f (--force) when installing to replace an already installed version

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -732,7 +732,7 @@ sub run_command_install {
     }
 
     my $installation_name = $self->{as} || $dist;
-    if ($self->is_installed( $installation_name )) {
+    if ($self->is_installed( $installation_name ) && !$self->{force}) {
         die "\nABORT: $installation_name is already installed.\n\n";
     }
 


### PR DESCRIPTION
Hi gugod.

I had forgot to build my 5.14.1 with useshrplib but since it was already installed I figured "perlbrew install -f 5.14.1" would work but it didn't. Hence the patch.

Cheers,
Claes
