### PR TITLE
avoid reading a nonexistent directory

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1551,7 +1551,10 @@ sub run_command_lib_list {
         $current = $self->current_perl . "@" . $self->env("PERLBREW_LIB");
     }
 
-    opendir my $dh, catdir($PERLBREW_HOME,  "libs");
+    my $dir = catdir($PERLBREW_HOME,  "libs");
+    return unless -d $dir;
+
+    opendir my $dh, $dir or die "open $dir failed: $!";
     my @libs = grep { !/^\./ } readdir($dh);
 
     for (@libs) {


### PR DESCRIPTION
When I first tried to run 'perlbrew lib list', it died with: 'readdir() attempted on invalid dirhandle $dh at ... line 1555.', so I guess this simple fix would avoid that...(seems that I removed the ~/.perlbrew unexpectedly)
