### PR TITLE
Remove dependency on Text::Levenshtein module.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ repository 'git://github.com/gugod/App-perlbrew.git';
 
 requires
     'File::Path::Tiny'  => '0.1',
-    'Text::Levenshtein' => '0.04',
+    'List::Util'        => '0';
     'Devel::PatchPerl'  => '0.46',
     'local::lib'        => '1.0';
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -5,7 +5,7 @@ use 5.008;
 use Getopt::Long ();
 use File::Spec::Functions qw( catfile catdir );
 use File::Path::Tiny;
-use Text::Levenshtein ();
+use List::Util qw( min );
 use FindBin;
 
 our $VERSION = "0.30";
@@ -319,6 +319,27 @@ sub commands {
     return @commands;
 }
 
+# straight copy of Wikipedia's "Levenshtein Distance"
+sub editdist {
+    my @a = split //, shift;
+    my @b = split //, shift;
+
+    # There is an extra row and column in the matrix. This is the
+    # distance from the empty string to a substring of the target.
+    my @d;
+    $d[$_][0] = $_ for (0 .. @a);
+    $d[0][$_] = $_ for (0 .. @b);
+
+    for my $i (1 .. @a) {
+        for my $j (1 .. @b) {
+            $d[$i][$j] = ($a[$i-1] eq $b[$j-1] ? $d[$i-1][$j-1]
+                : 1 + min($d[$i-1][$j], $d[$i][$j-1], $d[$i-1][$j-1]));
+        }
+    }
+
+    return $d[@a][@b];
+}
+
 sub find_similar_commands {
     my ( $self, $command ) = @_;
     my $SIMILAR_DISTANCE = 6;
@@ -328,7 +349,7 @@ sub find_similar_commands {
     } grep {
         defined
     } map {
-        my $d =  Text::Levenshtein::fastdistance($_, $command);
+        my $d = editdist($_, $command);
 
         ($d < $SIMILAR_DISTANCE) ? [ $_, $d ] : undef
     } $self->commands;

--- a/t/11.editdist.t
+++ b/t/11.editdist.t
@@ -1,0 +1,15 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use App::perlbrew;
+
+*ed = *App::perlbrew::editdist;
+is ed(qw/Joe Jim/), 2;
+is ed(qw/Jack Jill/), 3;
+is ed(qw/Jim Jimmy/), 2;
+is ed(qw/superman supergirl/), 4;
+is ed(qw/supercalifragilisticexpyalligocious superman/), 29;
+is ed(qw/foo bar/), 3;
+
+done_testing;


### PR DESCRIPTION
Creates an editdist sub instead of using Text::Levenshtein. The module is
a little funky and the algorithm is not hard to implement.

Adds t/11.editdist.t. This is more testing than Text::Levenshtein does.

I dislike the Text::Levenshtein module because it spews warnings when they are turned on. The warnings are turned on by the test harness with 'make test'. The module seems kind of crappy and short enough to implement the algorithm ourselves. The new editdist sub is 20 lines; three of which are comments.

My patch adds a dependency on List::Util for the use of the min() function. Maybe that is a little hypocritical in this situation and I should write a min() function...
