### PR TITLE
Separate the bash completion code from etc/bashrc

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -136,6 +136,10 @@ RC
 
 sub BASH_COMPLETION_CONTENT() {
     return <<'COMPLETION';
+if [[ -n ${ZSH_VERSION-} ]]; then
+    autoload -U +X bashcompinit && bashcompinit
+fi
+
 export PERLBREW="command perlbrew"
 _perlbrew_compgen()
 {


### PR DESCRIPTION
@gfx's bash completion (#164) is extremely useful.
However, I don't like that completion is _forcibly_ defined and enabled when you do `source $PERLBREW_ROOT/etc/bashrc`.
Especially for Zsh users, doing it with `bashcompinit` disabled is just a bad idea. Even with that resolved, some may still prefer to use, say, [dbb's](https://github.com/dbb/zsh-stuff/blob/master/_perlbrew) or [lapis25's one](https://github.com/lapis25/dotfiles/blob/master/.zsh/functions/_perlbrew) specialized for Zsh. Or there might also be those who never want to use any kind of completion.

So, I have moved the completion part into a separate file named `perlbrew-completion.bash` (imitating the great [`git-completion.bash`](https://github.com/git/git/blob/master/contrib/completion/git-completion.bash#L76)), and also added a workaround for Zsh. So that you can turn on the completion by just doing `source $PERLBREW_ROOT/etc/perlbrew-completion.bash` whenever you like, regardless of which shell (Bash or Zsh) you are using. WDYT?
