### PR TITLE
Use 0 instead of $[

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1158,7 +1158,7 @@ sub run_command_list {
     for my $i ( $self->installed_perls ) {
         print $i->{is_current} ? '* ': '  ',
             $i->{name},
-            (index($i->{name}, $i->{version}) < $[) ? " ($i->{version})" : "",
+            (index($i->{name}, $i->{version}) < 0) ? " ($i->{version})" : "",
             "\n";
 
         for my $lib (@{$i->{libs}}) {


### PR DESCRIPTION
When running perlbrew commands and the current version of perl is >= 5.12, you will often see the following warning:

```
$[ used in numeric lt (<) (did you mean $] ?) at /loader/0xf1bc38/App/perlbrew.pm line 1126.
```

Due to the fact that use of $[ is [deprecated](http://search.cpan.org/~jesse/perl-5.12.0/pod/perl5120delta.pod#Deprecations) as of 5.12 and deprecated warnings are on by default.

This change simply uses "0" instead of "$[".

It should be compatible with any 5.x version of perl since:
- According to [perlvar](http://perldoc.perl.org/perlvar.html) "As of release 5 of Perl, assignment to $[ is treated as a compiler directive, and cannot influence the behavior of any other file."
- perlbrew.pm does not redefine $[ anywhere
