### PR TITLE
Simplify option detection in Bash perlbrew function

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -81,7 +81,7 @@ perlbrew () {
     local short_option
     export SHELL
 
-    if [[ `echo $1 | awk 'BEGIN{FS=""}{print $1}'` = '-' ]]; then
+    if [[ $1 == -* ]]; then
         short_option=$1
         shift
     else


### PR DESCRIPTION
This change avoids forking an `awk` process to do something that can straightforwardly be done in the shell. In addition, avoiding Awk seems valuable for a project whose target audience (Perl programmers) don’t necessarily know it.
