### PR TITLE
get correct perl version with basename when "do_install_archive"

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -5,6 +5,7 @@ use 5.008;
 use Capture::Tiny;
 use Getopt::Long ();
 use File::Spec::Functions qw( catfile catdir );
+use File::Basename;
 use File::Path::Tiny;
 use FindBin;
 use CPAN::Perl::Releases;
@@ -1059,7 +1060,7 @@ sub do_install_archive {
     my $dist_version;
     my $installation_name;
 
-    if ($dist_tarball_path =~ m{perl-?(5.+)\.tar\.(gz|bz2)\Z}) {
+    if (basename($dist_tarball_path) =~ m{perl-?(5.+)\.tar\.(gz|bz2)\Z}) {
         $dist_version = $1;
         $installation_name = "perl-${dist_version}";
     }


### PR DESCRIPTION
When I tried to install the lastest perl from tarball

> perlbrew install /Users/alec/perl5/perlbrew/dists/perl-5.16.0-RC2.tar.gz

I got a wrong perl version number, like:

> dist_version = 5/perlbrew/dists/perl-5.16.0-RC2

I believe it was caused by the greedy RE when parsing tarball path.

Consider use `basename` to get the correct version number?
