### PR TITLE
Change 'install' to 'self-install'

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1516,7 +1516,7 @@ sub run_command_self_upgrade {
         print "Your perlbrew is up-to-date.\n";
         return;
     }
-    system $TMP_PERLBREW, "install";
+    system $TMP_PERLBREW, "self-install";
     unlink $TMP_PERLBREW;
 }
 


### PR DESCRIPTION
I got a deprecation warning when I did a `perlbrew self-upgrade` this morning, so I fixed it.
