### PR TITLE
Suppress warning about setting $MANPATH

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1904,7 +1904,7 @@ __perlbrew_set_path () {
     fi
 
     export PATH="$PERLBREW_PATH:$PATH_WITHOUT_PERLBREW"
-    export MANPATH_WITHOUT_PERLBREW="$(perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_ROOT}) } split/:/,qx(manpath);')"
+    export MANPATH_WITHOUT_PERLBREW="$(perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_ROOT}) } split/:/,qx(manpath -q);')"
     if [ -n "$PERLBREW_MANPATH" ]; then
         export MANPATH="$PERLBREW_MANPATH:$MANPATH_WITHOUT_PERLBREW"
     else


### PR DESCRIPTION
When you have set $MANPATH manualy, calling manpath in .bashrc will
print a warning when starting a terminal session. Calling manpath with
the -q option will suppress this warning.
