### PR TITLE
Make sure we have a non-empty $PERLBREW_PATH

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1940,7 +1940,13 @@ __perlbrew_set_path () {
     fi
 
     export PATH_WITHOUT_PERLBREW=` perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_HOME}) < 0 } grep { index($_, $ENV{PERLBREW_ROOT}) < 0 } split/:/,$ENV{PATH};' `
-    export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
+
+    if [ -n "$PERLBREW_PATH" ]; then 
+          export PATH=${PERLBREW_PATH}/bin:${PATH_WITHOUT_PERLBREW}
+      else
+          export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
+    fi
+
     hash -r
 }
 

--- a/perlbrew
+++ b/perlbrew
@@ -94,7 +94,13 @@ $fatpacked{"App/perlbrew.pm"} = <<'APP_PERLBREW';
       fi
   
       export PATH_WITHOUT_PERLBREW=` perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_HOME}) < 0 } grep { index($_, $ENV{PERLBREW_ROOT}) < 0 } split/:/,$ENV{PATH};' `
-      export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
+      
+      if [ -n "$PERLBREW_PATH" ]; then 
+          export PATH=${PERLBREW_PATH}/bin:${PATH_WITHOUT_PERLBREW}
+      else
+          export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
+      fi
+
       hash -r
   }
   


### PR DESCRIPTION
Issue when installing for a multiple user setup and customizing PERLBREW_ROOT path. If PERLBREW_ROOT isn't set we will have an empty PERLBREW_PATH for a user trying to source ${PERLBREW_ROOT}/etc/bashrc for the first time unless there is a perl version installed?
