### PR TITLE
bash does not like an empty if ... else block, so inserted a line "true"

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1957,6 +1957,7 @@ __perlbrew_activate() {
 
     if [[ -z "$PERLBREW_PERL" ]]; then
         # Nothing to activate...
+        true
     else
         if [[ -z "$PERLBREW_LIB" ]]; then
             eval "$($perlbrew_command env $PERLBREW_PERL)"

--- a/perlbrew
+++ b/perlbrew
@@ -111,6 +111,7 @@ $fatpacked{"App/perlbrew.pm"} = <<'APP_PERLBREW';
   
       if [[ -z "$PERLBREW_PERL" ]]; then
           # Nothing to activate...
+          true
       else
           if [[ -z "$PERLBREW_LIB" ]]; then
               eval "$($perlbrew_command env $PERLBREW_PERL)"


### PR DESCRIPTION
On perlbrew install yesterday, had problem that was fixed by https://github.com/gugod/App-perlbrew/pull/236
installed development on top of existing install with the following, and found another issue:

```
ashley@tantrum ~ $ curl -kL https://raw.github.com/gugod/App-perlbrew/develop/perlbrew-install | perl -pe 's|/master/perlbrew|/develop/perlbrew/|' | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1022  100  1022    0     0   2797      0 --:--:-- --:--:-- --:--:--  3418

## Download the latest perlbrew

## Installing perlbrew
perlbrew is installed: ~/perl5/perlbrew/bin/perlbrew

perlbrew root (~/perl5/perlbrew) is initialized.

Append the following piece of code to the end of your ~/.bash_profile and start a
new shell, perlbrew should be up and fully functional from there:

    source ~/perl5/perlbrew/etc/bashrc

Simply run `perlbrew` for usage details.

Happy brewing!

## Installing patchperl

## Done.
ashley@tantrum ~ $ source ~/perl5/perlbrew/etc/bashrc
-bash: /home/ashley/perl5/perlbrew/etc/bashrc: line 44: syntax error near unexpected token `else'
-bash: /home/ashley/perl5/perlbrew/etc/bashrc: line 44: `    else'
ashley@tantrum ~ $ # inserted line of "true" there
ashley@tantrum ~ $ source ~/perl5/perlbrew/etc/bashrc
ashley@tantrum ~ $ bash --version
GNU bash, version 4.1.9(2)-release (x86_64-pc-linux-gnu)
Copyright (C) 2009 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
