### PR TITLE
Fixed the order since -n returns true if non-zero

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1941,10 +1941,10 @@ __perlbrew_set_path () {
 
     export PATH_WITHOUT_PERLBREW=` perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_HOME}) < 0 } grep { index($_, $ENV{PERLBREW_ROOT}) < 0 } split/:/,$ENV{PATH};' `
 
-    if [ -n "$PERLBREW_PATH" ]; then 
-          export PATH=${PERLBREW_PATH}/bin:${PATH_WITHOUT_PERLBREW}
-      else
-          export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
+    if [ -n "$PERLBREW_PATH" ]; then
+        export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}  
+    else
+        export PATH=${PERLBREW_ROOT}/bin:${PATH_WITHOUT_PERLBREW}
     fi
 
     hash -r

--- a/perlbrew
+++ b/perlbrew
@@ -95,10 +95,10 @@ $fatpacked{"App/perlbrew.pm"} = <<'APP_PERLBREW';
   
       export PATH_WITHOUT_PERLBREW=` perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_HOME}) < 0 } grep { index($_, $ENV{PERLBREW_ROOT}) < 0 } split/:/,$ENV{PATH};' `
   
-      if [ -n "$PERLBREW_PATH" ]; then 
-            export PATH=${PERLBREW_PATH}/bin:${PATH_WITHOUT_PERLBREW}
-        else
-            export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
+      if [ -n "$PERLBREW_PATH" ]; then
+          export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}  
+      else
+          export PATH=${PERLBREW_ROOT}/bin:${PATH_WITHOUT_PERLBREW}
       fi
   
       hash -r


### PR DESCRIPTION
I messed up the order, I think if PERLBREW_PATH is empty we should use PERLBREW_ROOT. Is that a correct thinking?
