### PR TITLE
Support for old perl version numbers

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -760,8 +760,7 @@ sub do_install_blead {
 sub do_install_release {
     my $self = shift;
     my $dist = shift;
-
-    my ($dist_name, $dist_version) = $dist =~ m/^(.*)-([\d.]+(?:-RC\d+)?)$/;
+    my ($dist_name, $dist_version) = @_;
 
     my ($dist_tarball, $dist_tarball_url) = $self->perl_release($dist_version);
     my $dist_tarball_path = catfile($self->root, "dists", $dist_tarball);
@@ -771,12 +770,12 @@ sub do_install_release {
             if $self->{verbose};
     }
     else {
-        print "Fetching $dist as $dist_tarball_path\n" unless $self->{quiet};
+        print "Fetching $dist_name $dist_version as $dist_tarball_path\n" unless $self->{quiet};
         $self->download( $dist_tarball_url, $dist_tarball_path );
     }
 
     my $dist_extracted_path = $self->do_extract_tarball($dist_tarball_path);
-    $self->do_install_this($dist_extracted_path,$dist_version, $dist);
+    $self->do_install_this( $dist_extracted_path, $dist_version, $dist );
     return;
 }
 
@@ -816,7 +815,7 @@ sub run_command_install {
         }
     }
     elsif ($dist_name eq 'perl') {
-        $self->do_install_release($dist);
+        $self->do_install_release( $dist, $dist_name, $dist_version );
     }
     else {
         die $help_message;


### PR DESCRIPTION
This cleans up some of the regex and parameter handling around Perl version numbers, to allow ancient-style versions like perl5.004_05. So you can now say `perlbrew install perl5.004_05` and it will at least download the tarball, though compilation doesn't quite work yet (at least not on MacOS X). I think I'll need to add some version-dependent logic for the Configure script, but I haven't looked into it yet.
