### PR TITLE
Escape envvars in regexes with \Q and \E (fixes test failure on OS X)

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -220,7 +220,7 @@ sub env {
 sub path_with_tilde {
     my ($self, $dir) = @_;
     my $home = $self->env('HOME');
-    $dir =~ s/^$home/~/ if $home;
+    $dir =~ s/^\Q$home\E/~/ if $home;
     return $dir;
 }
 
@@ -1202,7 +1202,7 @@ sub perlbrew_env {
             no warnings 'uninitialized';
 
             if ($ENV{PERL_LOCAL_LIB_ROOT}
-                && $ENV{PERL_LOCAL_LIB_ROOT} =~ /^$PERLBREW_HOME/
+                && $ENV{PERL_LOCAL_LIB_ROOT} =~ /^\Q$PERLBREW_HOME\E/
             ) {
                 my %deactivate_env = local::lib->build_deact_all_environment_vars_for($ENV{PERL_LOCAL_LIB_ROOT});
                 @env{keys %deactivate_env} = values %deactivate_env;
@@ -1229,7 +1229,7 @@ sub perlbrew_env {
         }
         else {
             my $libroot = $self->env("PERL_LOCAL_LIB_ROOT");
-            if ($libroot && $libroot =~ /^$PERLBREW_HOME/) {
+            if ($libroot && $libroot =~ /^\Q$PERLBREW_HOME\E/) {
                 require local::lib;
                 my %deactivate_env = local::lib->build_deact_all_environment_vars_for($libroot);
                 @env{keys %deactivate_env} = values %deactivate_env;
@@ -1237,7 +1237,7 @@ sub perlbrew_env {
             }
             if (my $perl5lib = $self->env("PERL5LIB")) {
                 my @perl5libs = split $Config{path_sep} => $perl5lib;
-                my @prestine_perl5libs = grep { !/^$PERLBREW_HOME/ } @perl5libs;
+                my @prestine_perl5libs = grep { !/^\Q$PERLBREW_HOME\E/ } @perl5libs;
                 if (@prestine_perl5libs) {
                     $env{PERL5LIB} = join $Config{path_sep}, @prestine_perl5libs;
                 }
@@ -1249,7 +1249,7 @@ sub perlbrew_env {
     }
     else {
         my $libroot = $self->env("PERL_LOCAL_LIB_ROOT");
-        if ($libroot && $libroot =~ /^$PERLBREW_HOME/) {
+        if ($libroot && $libroot =~ /^\Q$PERLBREW_HOME\E/) {
             require local::lib;
             my %deactivate_env = local::lib->build_deact_all_environment_vars_for($libroot);
             @env{keys %deactivate_env} = values %deactivate_env;


### PR DESCRIPTION
This patch fixes a test failure when installing App::perlbrew 0.58 on OS X 10.6.  The test failure is in command-exec.t (see end of message) and occurs because $PERLBREW_HOME is set to a tmpdir with the string '+++' in the path name.  When this string is used in a regex, perl dies complaining about nested quantifiers. The fix is to quote $PERLBREW_HOME when it's used in regexes.  This occurs four times in perlbrew_env().   A similar but unlikely issue could occur with $home in path_with_tilde(), so I've changed that, too.

Please let me know if you'd like me to make adjustments to the patch and thank you for all of your hard work on this amazing module!

Cheers,
Fitz Elliott

 t/command-exec.t .................... 1/? 

 #   Failed test 'perlbrew exec perl -E "say 42" invokes all perls' by dying:
 #     Nested quantifiers in regex; marked by <-- HERE in m/^/var/folders/dr/dr7jbASTF1yPnL76bBF-tk+++ <-- HERE TI/-Tmp-/f29LHerltl/ at /Users/fge7z/code/cpan-modules/App-perlbrew/blib/lib/App/perlbrew.pm line 1240.

 expected do_system to be called exactly 4 times, but it was called 0 times

 #   Failed test 'perlbrew exec --with perl-5.12.3 perl -E "say 42" invokes perl-5.12.3/bin/perl' by dying:
 #     Nested quantifiers in regex; marked by <-- HERE in m/^/var/folders/dr/dr7jbASTF1yPnL76bBF-tk+++ <-- HERE TI/-Tmp-/f29LHerltl/ at /Users/fge7z/code/cpan-modules/App-perlbrew/blib/lib/App/perlbrew.pm line 1240.

 expected do_system to be called exactly once, but it was called 0 times
 # Looks like you failed 2 tests of 2.
 t/command-exec.t .................... Dubious, test returned 2 (wstat 512, 0x200)
 Failed 2/2 subtests 
