### PR TITLE
Don't throw warnings if perl-5.8.0 has been installed with Perlbrew.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,14 +13,15 @@ requires
     'CPAN::Perl::Releases' => '0.76';
 
 test_requires
-    'Test::Simple'    => '0.98',
-    'Test::More'      => '0',
-    'Test::Output'    => '0',
-    'Test::Exception' => '0',
-    'Test::Spec'      => '0',
-    'Path::Class'     => '0',
-    'IO::All'         => '0',
-    'File::Temp'      => '0';
+    'Test::Simple'     => '0.98',
+    'Test::More'       => '0',
+    'Test::Output'     => '0',
+    'Test::Exception'  => '0',
+    'Test::NoWarnings' => '0',
+    'Test::Spec'       => '0',
+    'Path::Class'      => '0',
+    'IO::All'          => '0',
+    'File::Temp'       => '0';
 
 install_script 'bin/perlbrew';
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1114,7 +1114,7 @@ sub format_perl_version {
     return sprintf "%d.%d.%d",
       substr( $version, 0, 1 ),
       substr( $version, 2, 3 ),
-      substr( $version, 5 );
+      substr( $version, 5 ) || 0;
 
 }
 

--- a/t/02.format_perl_version.t
+++ b/t/02.format_perl_version.t
@@ -6,6 +6,7 @@ use Test::More;
 use lib qw(lib);
 
 use App::perlbrew;
+use Test::NoWarnings;
 
 my @test_cases = (
     {
@@ -20,9 +21,13 @@ my @test_cases = (
         raw    => q{5.012002},
         parsed => q{5.12.2},
     },
+    {
+        raw    => q{5.008},
+        parsed => q{5.8.0},
+    },
 );
 
-plan tests => scalar @test_cases;
+plan tests => scalar @test_cases + 1;
 {
     my $app = App::perlbrew->new();
  TEST:


### PR DESCRIPTION
I brewed perl-5.8.0 awhile back and had been getting warnings every time I used perlbrew:

```
$ perlbrew list
Argument "" isn't numeric in sprintf at /usr/local/share/perl/5.10.1/App/perlbrew.pm line 1114.
  perl-5.17.6
  perl-5.8.0
  perl-5.8.0@5.8.0
  perl-5.8.3
  perl-5.8.3@5.8.3
  perl-5.8.8
```

This patch should safely make the warning go away.
