### PR TITLE
New features for `perlbrew install`

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -203,6 +203,9 @@ Options for C<install> command:
     -j $n          Parallel building and testing. ex. C<perlbrew install -j 5 perl-5.14.2>
     -n --notest    Skip testing
 
+       --switch    Automatically switch to this Perl once successfully
+                   installed, as if with `perlbrew switch <version>`
+
        --as        Install the given version of perl by a name.
                    ex. C<perlbrew install perl-5.6.2 --as legacy-perl>
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -144,6 +144,7 @@ sub new {
         'help|h',
         'version',
         'root=s',
+        'switch',
 
         # options passed directly to Configure
         'D=s@',
@@ -868,6 +869,9 @@ sub run_command_install {
         die $help_message;
     }
 
+    $self->switch_to($installation_name)
+        if $self->{switch};
+
     return;
 }
 
@@ -1381,6 +1385,12 @@ sub run_command_switch {
             ( $current ? "to $current" : 'off' );
         return;
     }
+
+    $self->switch_to($dist, $alias);
+}
+
+sub switch_to {
+    my ( $self, $dist, $alias ) = @_;
 
     die "Cannot use for alias something that starts with 'perl-'\n"
       if $alias && $alias =~ /^perl-/;

--- a/t/installation3.t
+++ b/t/installation3.t
@@ -16,12 +16,16 @@ use Test::More;
         return map { "perl-$_" }
             qw<5.8.9 5.17.7 5.16.2 5.14.3 5.12.5 5.10.1>;
     }
+
+    sub App::perlbrew::switch_to {
+        shift->current_perl(shift);
+    }
 }
 
-plan tests => 2;
+plan tests => 3;
 
 {
-    my $app = App::perlbrew->new("install", "perl-stable");
+    my $app = App::perlbrew->new("install", "--switch", "perl-stable");
     $app->run;
 
     my @installed = $app->installed_perls;
@@ -29,6 +33,10 @@ plan tests => 2;
 
     is $installed[0]{name}, "perl-5.16.2",
         "install perl-stable installs correct perl";
+
+    ok $installed[0]{is_current},
+        "install --switch automatically switches to the installed perl"
+            or diag explain $installed[0];
 }
 
 done_testing;


### PR DESCRIPTION
This pull request fixes a minor bug, and adds two features to `perlbrew install`:
- You can use `stable` or `perl-stable` as the name of a Perl to install, and it gets resolved to the most recent stable Perl (5.even.x)
- A new `--switch` option automatically switches to the newly-installed Perl on completion

The net effect is that newcomers to Perl can be recommended to run `perlbrew install --switch stable` on a new Perlbrew installation, and easily get a fresh, up-to-date Perl environment (even if the instructions they're reading are a year old or more).

Please let me know if there are any changes you'd like me to make.

Thanks for Perlbrew!
