### PR TITLE
do not rely on unreliable hash ordering

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1467,7 +1467,8 @@ sub run_command_env {
     my %env = $self->perlbrew_env($name);
 
     if ($self->env('SHELL') =~ /(ba|k|z|\/)sh\d?$/) {
-        while (my ($k, $v) = each(%env)) {
+        for my $k (sort keys %env) {
+            my $v = $env{$k};
             if (defined $v) {
                 $v =~ s/(\\")/\\$1/g;
                 print "export $k=\"$v\"\n";
@@ -1478,7 +1479,8 @@ sub run_command_env {
         }
     }
     else {
-        while (my ($k, $v) = each(%env)) {
+        for my $k (sort keys %env) {
+            my $v = $env{$k};
             if (defined $v) {
                 $v =~ s/(\\")/\\$1/g;
                 print "setenv $k \"$v\"\n";

--- a/t/command-env.t
+++ b/t/command-env.t
@@ -35,10 +35,10 @@ describe "env command," => sub {
                 $app->run;
             } <<"OUT";
 export PERLBREW_MANPATH="$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/man"
-export PERLBREW_PERL="perl-5.14.1"
-export PERLBREW_VERSION="$App::perlbrew::VERSION"
 export PERLBREW_PATH="$App::perlbrew::PERLBREW_ROOT/bin:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/bin"
+export PERLBREW_PERL="perl-5.14.1"
 export PERLBREW_ROOT="$App::perlbrew::PERLBREW_ROOT"
+export PERLBREW_VERSION="$App::perlbrew::VERSION"
 OUT
         };
     };
@@ -54,16 +54,16 @@ OUT
             stdout_is {
                 $app->run;
             } <<"OUT";
+export PERL5LIB="$lib_dir/lib/perl5${PERL5LIB_maybe}"
+export PERLBREW_LIB="nobita"
+export PERLBREW_MANPATH="$lib_dir/man:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/man"
+export PERLBREW_PATH="$lib_dir/bin:$App::perlbrew::PERLBREW_ROOT/bin:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/bin"
 export PERLBREW_PERL="perl-5.14.1"
+export PERLBREW_ROOT="$App::perlbrew::PERLBREW_ROOT"
 export PERLBREW_VERSION="$App::perlbrew::VERSION"
+export PERL_LOCAL_LIB_ROOT="$lib_dir"
 export PERL_MB_OPT="--install_base $lib_dir"
 export PERL_MM_OPT="INSTALL_BASE=$lib_dir"
-export PERL_LOCAL_LIB_ROOT="$lib_dir"
-export PERL5LIB="$lib_dir/lib/perl5${PERL5LIB_maybe}"
-export PERLBREW_MANPATH="$lib_dir/man:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/man"
-export PERLBREW_LIB="nobita"
-export PERLBREW_PATH="$lib_dir/bin:$App::perlbrew::PERLBREW_ROOT/bin:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/bin"
-export PERLBREW_ROOT="$App::perlbrew::PERLBREW_ROOT"
 OUT
         }
     }


### PR DESCRIPTION
App::perlbrew is nearly entirely uninstallable on blead because it relies on hash ordering for its tests.  This fixes that.
