### PR TITLE
Fixed bug with perlbrew env where PERL5LIB would be unset

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1248,7 +1248,7 @@ sub perlbrew_env {
                 @ENV{keys %env} = values %env;
                 my %lib_env = local::lib->build_environment_vars_for($base, 0, 1);
 
-                $lib_env{PERL5LIB} = (split($Config{path_sep}, $lib_env{PERL5LIB}, 2))[1];
+                $lib_env{PERL5LIB} = (split($Config{path_sep}, $lib_env{PERL5LIB}, 2))[-1];
 
                 $env{PERLBREW_PATH}    = catdir($base, "bin") . ":" . $env{PERLBREW_PATH};
                 $env{PERLBREW_MANPATH} = catdir($base, "man") . ":" . $env{PERLBREW_MANPATH};


### PR DESCRIPTION
If PERL5LIB was naturally unset, perlbrew env wouldn't find the perlbrew
supplied PERL5LIB. I've fixed this, assuming that PERL5LIB is always
in the last position of PERL5LIB (which your code seemed to assume as well).
