### PR TITLE
Fixed bashrc that perlbrew init generates

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2042,7 +2042,7 @@ __perlbrew_set_path () {
     fi
     unset MANPATH_WITHOUT_PERLBREW
 
-    PATH_WITHOUT_PERLBREW=`$perlbrew_command display-pristine-path`
+    PATH_WITHOUT_PERLBREW=$(eval $perlbrew_command display-pristine-path)
     if [ -n "$PERLBREW_PATH" ]; then
         export PATH=${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}
     else
@@ -2058,9 +2058,9 @@ __perlbrew_activate() {
 
     if [[ -n "$PERLBREW_PERL" ]]; then
         if [[ -z "$PERLBREW_LIB" ]]; then
-            eval "$($perlbrew_command env $PERLBREW_PERL)"
+            $(eval $perlbrew_command env $PERLBREW_PERL)
         else
-            eval "$(${perlbrew_command} env $PERLBREW_PERL@$PERLBREW_LIB)"
+            $(eval $perlbrew_command env $PERLBREW_PERL@$PERLBREW_LIB)
         fi
     fi
 
@@ -2068,7 +2068,7 @@ __perlbrew_activate() {
 }
 
 __perlbrew_deactivate() {
-    eval "$($perlbrew_command env)"
+    $(eval $perlbrew_command env)
     unset PERLBREW_PERL
     unset PERLBREW_LIB
     __perlbrew_set_path


### PR DESCRIPTION
zsh could not find the command "command perlbrew" as it was looking for a
binary named "command perlbrew", complete with spaces. This commit pops
and eval in the subshells so that this is no longer an issue.

It also standardizes the use of eval and subshells where necessary.
