### PR TITLE
Fix Can't call method "Capture::Tiny::capture" when install with --sitecustomize option

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1163,9 +1163,9 @@ sub do_system {
 sub do_capture {
   my ($self, $cmd) = @_;
   require Capture::Tiny;
-  return Capture::Tiny::capture {
+  return Capture::Tiny::capture( sub {
     $self->do_system($cmd);
-  };
+  });
 }
 
 sub format_perl_version {


### PR DESCRIPTION
Following error occurs when perlbrew install with --sitecustomize.

```
$ perlbrew install -f --notest 5.16.3 --as=perl-5.16 --sitecustomize /usr/irori/lib/perl/sitecustomize.pl
Installing /home/hirose31/perlbrew/build/perl-5.16.3 into ~/perlbrew/perls/perl-5.16

This could take a while. You can run the following command on another shell to track the status:

  tail -f ~/perlbrew/build.perl-5.16.3.log

sitelib='/home/hirose31/perlbrew/perls/perl-5.16/lib/site_perl/5.16.3';
Can't call method "Capture::Tiny::capture" without a package or object reference at /loader/0x14e6a18/App/perlbrew.pm line 19.
```

We cannot call prototyped Capture::Tiny::capture method when `require Capture::Tiny` (not `use Capture::Tiny`).

```
# OK
perl -e 'use Capture::Tiny;     Capture::Tiny::capture {system("/bin/date")}'

# NG
perl -e 'require Capture::Tiny; Capture::Tiny::capture {system("/bin/date")}'
Wed Apr 24 17:55:10 JST 2013
Can't call method "Capture::Tiny::capture" without a package or object reference at -e line 1.

# OK
perl -e 'require Capture::Tiny; Capture::Tiny::capture( sub {system("/bin/date")} )'
```

I suppose this caused by glitch of BEGIN phase and evaluate prototype of Capture::Tiny.
