### PR TITLE
remove documentation for the deprecated 'install-ack' command

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -40,7 +40,6 @@ Commands:
 
     install-patchperl  Install patchperl
     install-cpanm      Install cpanm, a friendly companion.
-    install-ack        Install ack
 
     download       Download the specified perl distribution tarball.
     mirror         Pick a preferred mirror site
@@ -506,12 +505,6 @@ Usage:
 
 Download the specified version of perl distribution tarball under C<<
 $PERLBREW_ROOT/dists/ >> directory.
-
-=head1 COMMAND: INSTALL-ACK
-
-Usage: perlbrew install-ack
-
-Install the standalone version of C<ack> program under C<$PERLBREW_ROOT/bin>.
 
 =head1 COMMAND: LIST-MODULES
 


### PR DESCRIPTION
Command itself was removed back in 9ccc373; docs are still kicking around.
