### PR TITLE
Run /usr/bin/perl directly, rather than using the #! mechanism.

### DIFF
--- a/perlbrew-install
+++ b/perlbrew-install
@@ -37,10 +37,10 @@ $PERLBREWDOWNLOAD || clean_exit 1
 echo
 echo "## Installing perlbrew"
 chmod +x $LOCALINSTALLER
-./$LOCALINSTALLER self-install || clean_exit 1
+/usr/bin/perl $LOCALINSTALLER self-install || clean_exit 1
 
 echo "## Installing patchperl"
-./$LOCALINSTALLER -f -q install-patchperl || clean_exit 1
+/usr/bin/perl $LOCALINSTALLER -f -q install-patchperl || clean_exit 1
 
 echo
 echo "## Done."


### PR DESCRIPTION
When TMPDIR is on a filesystem mounted with the noexec flag, then you can't just run the downloaded perlbrew.  This patch makes the install script run perl with the downloaded perlbrew as its first argument.

Using the hardcoded '/usr/bin/perl' seems wrong to me, but perlbrew has the #! line hardcoded to the same thing, so I guess it's ok?
