### PR TITLE
improve heuristic for detecting when we are running on a 64bit platform

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -252,6 +252,8 @@ C<install> plus the following ones:
 
     --all-variations     generates all the possible flavor combinations
 
+    --append $string     Appends the given string to the generated names
+
 For instance:
 
     perlbrew install-multiple 5.18.0 blead --both thread --both debug
@@ -269,6 +271,11 @@ Installs the following perls:
 
 (note that the C<multi> flavor is selected automatically because
 C<thread> requires it)
+
+Another example using custom compilation flags:
+
+    perlbrew install-multiple 5.18.0 --both thread -Doptimize='-O3' --append='-O3'
+
 
 =head1 COMMAND: UNINSTALL
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -209,6 +209,7 @@ sub new {
         noman => '',
         variation => '',
         both => [],
+	append => '',
     );
 
     $opt{$_} = '' for keys %flavor;
@@ -251,6 +252,7 @@ sub parse_cmdline {
         'quiet|q!',
         'verbose|v',
         'as=s',
+	'append=s',
         'help|h',
         'version',
         'root=s',
@@ -988,7 +990,7 @@ sub run_command_install {
         my $version = ($1 eq 'stable' ? $self->resolve_stable_version : $1);
         $dist = "perl-$version"; # normalize dist name
 
-        my $installation_name = ($self->{as} || $dist) . $self->{variation};
+        my $installation_name = ($self->{as} || $dist) . $self->{variation} . $self->{append};
         if (not $self->{force} and $self->is_installed( $installation_name )) {
             die "\nABORT: $installation_name is already installed.\n\n";
         }
@@ -1092,7 +1094,7 @@ sub run_command_install_multiple {
     my @variations = $self->check_and_calculate_variations;
     print join("\n",
                "Compiling the following distributions:",
-               map("    $_", @dists),
+               map("    $_$self->{append}", @dists),
                "  with the following variations:",
                map((/-(.*)/ ? "    $1" : "    default"), @variations),
                "", "");
@@ -1218,16 +1220,17 @@ sub do_install_this {
     my ($self, $dist_extracted_dir, $dist_version, $installation_name) = @_;
 
     my $variation = $self->{variation};
+    my $append = $self->{append};
 
     $self->{dist_extracted_dir} = $dist_extracted_dir;
-    $self->{log_file} = joinpath($self->root, "build.${installation_name}${variation}.log");
+    $self->{log_file} = joinpath($self->root, "build.${installation_name}${variation}${append}.log");
 
     my @d_options = @{ $self->{D} };
     my @u_options = @{ $self->{U} };
     my @a_options = @{ $self->{A} };
     my $sitecustomize = $self->{sitecustomize};
     $installation_name = $self->{as} if $self->{as};
-    $installation_name .= $variation;
+    $installation_name .= "$variation$append";
 
     $self->{installation_name} = $installation_name;
 


### PR DESCRIPTION
The heuristic used to detect when perl would compile as a 64bit perl natively was wrong.

I have replaced it by one that matches the logic in perl Configure script.
