### PR TITLE
installed_perls sort

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1436,17 +1436,19 @@ sub installed_perls {
     for (<$root/perls/*>) {
         my ($name) = $_ =~ m/\/([^\/]+$)/;
         my $executable = joinpath($_, 'bin', 'perl');
+        my $orig_version = `$executable -e 'print \$]'`;
 
         push @result, {
             name        => $name,
-            version     => $self->format_perl_version(`$executable -e 'print \$]'`),
+            orig_version=> $orig_version,
+            version     => $self->format_perl_version($orig_version),
             is_current  => ($self->current_perl eq $name) && !$self->env("PERLBREW_LIB"),
             libs => [ $self->local_libs($name) ],
             executable  => $executable
         };
     }
 
-    return @result;
+    return sort { $a->{orig_version} <=> $b->{orig_version} or $a->{name} cmp $b->{name}  } @result;
 }
 
 sub local_libs {


### PR DESCRIPTION
Previously commands like `list` `exec` iterated over perls in ASCII order (or maybe filesystem order?). i.e. perl-5.8.0 goes after perl-5.19.1

this fix make it sorted in ascending order by version.

if it's OK, I can continue and add some tests + fix `available_perls` similar way.
(note that `exec` with `--with` argument can be executed in order defined by `--with`)
