### PR TITLE
Make bashrc use PERLBREW_ROOT at installation time

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2371,7 +2371,7 @@ sub _load_config {
 }
 
 sub BASHRC_CONTENT() {
-    return "export PERLBREW_BASHRC_VERSION=$VERSION\n\n" . <<'RC';
+    return "export PERLBREW_BASHRC_VERSION=$VERSION\n\n" . sprintf <<'RC', $PERLBREW_ROOT;
 
 __perlbrew_reinit() {
     if [[ ! -d "$PERLBREW_HOME" ]]; then
@@ -2497,7 +2497,7 @@ perlbrew () {
     return ${exit_status:-0}
 }
 
-[[ -z "$PERLBREW_ROOT" ]] && export PERLBREW_ROOT="$HOME/perl5/perlbrew"
+[[ -z "$PERLBREW_ROOT" ]] && export PERLBREW_ROOT="%s"
 [[ -z "$PERLBREW_HOME" ]] && export PERLBREW_HOME="$HOME/.perlbrew"
 
 if [[ ! -n "$PERLBREW_SKIP_INIT" ]]; then


### PR DESCRIPTION
If the generated bashrc file includes (by default) the value of `PERLBREW_ROOT` at install time, the user doesn't have to remember to add a line in bashrc (or wherever) to also set PERLBREW_ROOT again. 

(This explanation's a bit convoluted, sorry...)

This might resolve some potential confusion for people (like me) who change `PERLBREW_ROOT` before installation, but then don't read the man page before adding the necessary `source` line to `~/.bashrc`.  In a new shell, `PERLBREW_ROOT` won't be set and so will default to `$HOME/perl5/perlbrew`, which won't exist. 

Because the bashrc file then uses the value of this variable to find the `perlbrew` _command_, later (when `__perlbrew_set_path` is called), the line that sets `PATH_WITHOUT_PERLBREW` will return nothing (since `perlbrew` isn't found). Consequently, sourcing perlbrew's bashrc has the net effect of setting the path to contain _only_ the directory `$HOME/perl5/perlbrew/bin`, and clobbering anything else!

At any rate, having the generated bashrc inherit a default value of `PERLBREW_ROOT` from whatever it was at installation will avoid this problem for people like me (certainly I'm not alone) who don't read the full man page before firing up a new shell and running. (Alternately, you could just add a notice about export `PERLBREW_ROOT` before the notice about sourcing perlbrew's bashrc.)
