### PR TITLE
info command can display module info

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -20,6 +20,7 @@ perlbrew command syntax:
 Commands:
 
     init           Initialize perlbrew environment.
+    info           Show usefull information about the perlbrew installation
 
     install        Install perl
     uninstall      Uninstall the given installation
@@ -143,10 +144,15 @@ one-line installer manually, this command is invoked automatically.
 
 =head1 COMMAND: INFO
 
-Usage: perlbrew info
+=over 4
 
-The `info` command dumps a page of handful information for the perlbrew
-installation.
+=item B<info> [module]
+
+Usage: perlbrew info [ <module> ]
+
+Display usefull information about the perlbrew installation.
+
+If a module is given the version and location of the module is displayed.
 
 =head1 COMMAND: INSTALL
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2289,7 +2289,7 @@ sub resolve_installation_name {
 
 sub format_info_output
 {
-    my ($self) = @_;
+    my ($self, $module) = @_;
 
     my $out = '';
 
@@ -2313,12 +2313,25 @@ sub format_info_output
     for(map{"PERLBREW_$_"}qw(ROOT HOME PATH MANPATH)) {
         $out .= "    $_: " . ($self->env($_)||"") . "\n";
     }
+
+    if ( $module ) {
+        $out .= "\nModule: $module";
+        if ( eval qq|require $module| ) {
+            (my $f = $module) =~ s@::@/@g;
+            $f .= ".pm";
+            $out .= "\n";
+            $out .= "  Location: $INC{$f}\n";
+            $out .= "  Version: " . ($module->VERSION ? $module->VERSION : "no VERSION specified" ). "\n";
+        } else {
+            $out .= " could not be found, is it installed?\n";
+        }
+    }
     $out;
 }
 
 sub run_command_info {
-    my ($self) = @_;
-    print $self->format_info_output;
+    my ($self) = shift;
+    print $self->format_info_output(@_);
 }
 
 

--- a/t/command-info.t
+++ b/t/command-info.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::Spec;
 use Test::Output;
+use File::Spec;
 use Config;
 
 use App::perlbrew;
@@ -75,6 +76,95 @@ OUT
             $app->run();
         }, qr/$expected/;
     };
+
+    it "should display info for a module if the module is installed" => sub {
+        my $app = App::perlbrew->new;
+
+        my $mock_perl = { mock => 'current_perl' };
+        my $perl_path = $Config{perlpath};
+        my $module_name = "Data::Dumper";
+
+        $app->expects("current_perl")->returns($mock_perl)->at_least_once();
+        $app->expects("current_env")->returns('perl-5.8.9');
+        $app->expects("installed_perl_executable")->with($mock_perl)->returns($perl_path)->at_least_once();
+        $app->expects("configure_args")->with($mock_perl)->returns('config_args_value');
+        $app->expects("system_perl_shebang")->never;
+        local $ENV{PERLBREW_ROOT} = 'perlbrew_root_value';
+        local $ENV{PERLBREW_HOME} = 'perlbrew_home_value';
+        local $ENV{PERLBREW_PATH} = 'perlbrew_path_value';
+        local $ENV{PERLBREW_MANPATH} = 'perlbrew_manpath_value';
+
+        my $v = "KNOWN_VALUE";
+        (my $path_seperator = File::Spec->catdir( ( $v, $v ) ) ) =~ s/$v//g;
+        my $module_location = join $path_seperator, split( /::/, $module_name);
+
+my $expected = <<"OUT";
+Current perl:
+  Name: perl-5.8.9
+  Path: \Q$perl_path\E
+  Config: config_args_value
+  Compiled at: ...\\s+\\d{1,2}\\s+\\d{4}\\s+\\d{1,2}:\\d{2}:\\d{2}
+
+perlbrew:
+  version: \Q$App::perlbrew::VERSION\E
+  ENV:
+    PERLBREW_ROOT: perlbrew_root_value
+    PERLBREW_HOME: perlbrew_home_value
+    PERLBREW_PATH: perlbrew_path_value
+    PERLBREW_MANPATH: perlbrew_manpath_value
+
+Module: \Q$module_name\E
+  Location: .*\Q$module_location\E.pm
+  Version: [\\d\\._]+
+OUT
+
+        stdout_like sub {
+            $app->{args} = [ "info", $module_name];
+            $app->run();
+        }, qr/$expected/;
+    };
+
+    it "should display a message that the module can't be found if the module isn't installed" => sub {
+        my $app = App::perlbrew->new;
+
+        my $mock_perl = { mock => 'current_perl' };
+        my $perl_path = $Config{perlpath};
+        my $module_name = "SOME_FAKE_MODULE";
+
+        $app->expects("current_perl")->returns($mock_perl)->at_least_once();
+        $app->expects("current_env")->returns('perl-5.8.9');
+        $app->expects("installed_perl_executable")->with($mock_perl)->returns($perl_path)->at_least_once();
+        $app->expects("configure_args")->with($mock_perl)->returns('config_args_value');
+        $app->expects("system_perl_shebang")->never;
+        local $ENV{PERLBREW_ROOT} = 'perlbrew_root_value';
+        local $ENV{PERLBREW_HOME} = 'perlbrew_home_value';
+        local $ENV{PERLBREW_PATH} = 'perlbrew_path_value';
+        local $ENV{PERLBREW_MANPATH} = 'perlbrew_manpath_value';
+
+my $expected = <<"OUT";
+Current perl:
+  Name: perl-5.8.9
+  Path: \Q$perl_path\E
+  Config: config_args_value
+  Compiled at: ...\\s+\\d{1,2}\\s+\\d{4}\\s+\\d{1,2}:\\d{2}:\\d{2}
+
+perlbrew:
+  version: \Q$App::perlbrew::VERSION\E
+  ENV:
+    PERLBREW_ROOT: perlbrew_root_value
+    PERLBREW_HOME: perlbrew_home_value
+    PERLBREW_PATH: perlbrew_path_value
+    PERLBREW_MANPATH: perlbrew_manpath_value
+
+Module: $module_name could not be found, is it installed?.*
+OUT
+
+        stdout_like sub {
+            $app->{args} = [ "info", $module_name];
+            $app->run();
+        }, qr/$expected/;
+    };
+
 };
 
 


### PR DESCRIPTION
The info command now accepts a module name as a second argument.
If given information for that module will also be displayed.

The current information displayed is the version of the module and
the location of the module on disk.
