### PR TITLE
Fix perlbrew-install to check SSL cert validity

### DIFF
--- a/perlbrew-install
+++ b/perlbrew-install
@@ -16,11 +16,11 @@ LOCALINSTALLER="perlbrew-$$"
 
 echo
 if type curl >/dev/null 2>&1; then
-  PERLBREWDOWNLOAD="curl -k -f -sS -Lo $LOCALINSTALLER $PERLBREWURL"
+  PERLBREWDOWNLOAD="curl -f -sS -Lo $LOCALINSTALLER $PERLBREWURL"
 elif type fetch >/dev/null 2>&1; then
   PERLBREWDOWNLOAD="fetch -o $LOCALINSTALLER $PERLBREWURL"
 elif type wget >/dev/null 2>&1; then
-  PERLBREWDOWNLOAD="wget --no-check-certificate -nv -O $LOCALINSTALLER $PERLBREWURL"
+  PERLBREWDOWNLOAD="wget -nv -O $LOCALINSTALLER $PERLBREWURL"
 else
   echo "Need wget or curl to use $0"
   exit 1


### PR DESCRIPTION
Remove the curl and wget options that allow connecting to SSL that have certificates that can't be validated. Part of this was fixed in issue #335, but this part was missed.
