### PR TITLE
Typo in fish script

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2615,7 +2615,7 @@ function perlbrew;
     switch $argv[1]
         case use
             if test ( count $argv ) -eq 1 
-                if test -x "$PERLBREW_PERL" 
+                if test -z "$PERLBREW_PERL" 
                     echo "Currently using system perl"
                 else
                     echo "Currently using $PERLBREW_PERL"


### PR DESCRIPTION
must test for non-existence, not executability
