### PR TITLE
Fixes test for perlbrew arguments in fish shell

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2619,7 +2619,7 @@ end
 
 function perlbrew
 
-    test -z $argv
+    test -z "$argv"
     and echo "    Usage: perlbrew <command> [options] [arguments]"
     and echo "       or: perlbrew help"
     and return 1


### PR DESCRIPTION
Previously the error "test: unexpected argument at index 2: 'perl-5.18.2'" was reported when perlbrew was called with `perlbrew switch perl-5.18.2`. By interpolating the arguments into a string test receives a single argument rather than an array of arguments.
