### PR TITLE
Fixes perlbrew off when using fish shell

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2612,8 +2612,9 @@ end
 
 function __perlbrew_deactivate
     __perlbrew_set_env
-    set -r PERLBREW_PERL
-    set -r PERLBREW_LIB
+    set -x PERLBREW_PERL
+    set -x PERLBREW_LIB
+    set -x PERLBREW_PATH
     __perlbrew_set_path
 end
 


### PR DESCRIPTION
Previously this should report that perlbrew was successfully turned off, but would in fact not do so. Since the PERLBREW_PATH variable was not cleared it would be at the front of PATH and thus perlbrew's perl would be picked up first.

-r is not a valid flag for set, so I'm unsure what it was intended to do.
