### PR TITLE
Add support for a ".version" file in each perls root directory.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1484,6 +1484,10 @@ sub installed_perls {
             chomp $orig_version;
         } else {
             $orig_version = `$executable -e 'print \$]'`;
+            if ( defined $orig_version and length $orig_version ){
+                open my $fh, '>', $version_file;
+                print {$fh} $orig_version;
+            }
         }
 
         push @result, {


### PR DESCRIPTION
This is somewhat better than executing each and every perl on your
system for each and every new shell session.

Though this patch only adds support for such a file if it exists,
it does not yet cause such files to exist, and it only serves so I can
manually fix perlbrew from spewing in every terminal profusely.

[rt#92942](https://rt.cpan.org/Ticket/Display.html?id=92942)
