### PR TITLE
"perlbrew download stable" now works as one expects

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1158,6 +1158,9 @@ sub run_command_install_multiple {
 sub run_command_download {
     my ($self, $dist) = @_;
 
+    $dist = $self->resolve_stable_version
+        if $dist && $dist eq 'stable';
+
     my ($dist_version) = $dist =~ /^ (?:perl-?)? (.*) $/xs;
 
     die "\"$dist\" does not look like a perl distribution name. " unless $dist_version =~ /^\d\./;


### PR DESCRIPTION
That is, it looks for and downloads the latest stable tarball, much as
`perlbrew install stable` installs the latest stable version.
