### PR TITLE
installation of cpanm failed, because github certificate is unknown on centos 6.4 (minimal installation)

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -116,8 +116,8 @@ sub files_are_the_same {
         },
         wget => {
             test     => '--version >/dev/null 2>&1',
-            get      => '--quiet -O - {url}',
-            download => '--quiet -O {output} {url}',
+            get      => '--no-check-certificate --quiet -O - {url}',
+            download => '--no-check-certificate --quiet -O {output} {url}',
         },
         fetch => {
             test     => '--version >/dev/null 2>&1',


### PR DESCRIPTION
if i have curl and wget installed, and perlbrew choose wget to install software it fails installing cpanm. Because the github certificate is unknown. (even with ca-certificates package installed)

I don't know if it is a good option to add this. Maybe it is better to have a perlbrew command line switch to disable certificate check?
- added --no-check-certificate to wget options
