### PR TITLE
add --no-verify-peer to fetch args as github https urls do not verify

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -121,7 +121,7 @@ sub files_are_the_same {
         },
         fetch => {
             test     => '--version >/dev/null 2>&1',
-            get      => '-o - {url}',
+            get      => '--no-verify-peer -o - {url}',
             download => '{url}'
         }
     );

--- a/perlbrew-install
+++ b/perlbrew-install
@@ -18,7 +18,7 @@ echo
 if type curl >/dev/null 2>&1; then
   PERLBREWDOWNLOAD="curl -f -sS -Lo $LOCALINSTALLER $PERLBREWURL"
 elif type fetch >/dev/null 2>&1; then
-  PERLBREWDOWNLOAD="fetch -o $LOCALINSTALLER $PERLBREWURL"
+  PERLBREWDOWNLOAD="fetch --no-verify-peer -o $LOCALINSTALLER $PERLBREWURL"
 elif type wget >/dev/null 2>&1; then
   PERLBREWDOWNLOAD="wget -nv -O $LOCALINSTALLER $PERLBREWURL"
 else


### PR DESCRIPTION
Perlbrew install, install-cpanm, install-patchperl fail on freebsd due to SSL verification failures on github.com https urls.  Work around by using --no-verify-peer args to patch
