### PR TITLE
Updated PERLBREWURL to reflect Github API Changes

### DIFF
--- a/perlbrew-install
+++ b/perlbrew-install
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PERLBREWURL=https://raw.github.com/gugod/App-perlbrew/master/perlbrew
+PERLBREWURL=https://raw.githubusercontent.com/gugod/App-perlbrew/master/perlbrew
 
 if [ -z "$TMPDIR" ]; then
     if [ -d "/tmp" ]; then


### PR DESCRIPTION
The old URL was not longer working and should be updated to reflect the github API changes noted here:
https://developer.github.com/changes/2014-04-25-user-content-security/

I kept getting `curl: (22) The requested URL returned error: 400 Bad Request` errors with the current install file and noticed a redirect to a new domain.  Updating the URL seemed to fix these errors.  
