### PR TITLE
Fixed bug where dev branch version 5.21 or above doesn't work

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1290,7 +1290,7 @@ sub do_install_this {
     }
 
     unshift @d_options, qq(prefix=$perlpath);
-    push @d_options, "usedevel" if $dist_version =~ /5\.1[13579]|git|blead/;
+    push @d_options, "usedevel" if $dist_version =~ /5\.\d[13579]|git|blead/;
 
     unless (grep { /eval:scriptdir=/} @a_options) {
         push @a_options, "'eval:scriptdir=${perlpath}/bin'";


### PR DESCRIPTION
The changed line currently looks for dev versions in the 5.1x range.  The change allows the dev versions of perl above 5.20 to also work.
