### PR TITLE
Silence "print() on closed filehandle" warnings

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1491,8 +1491,9 @@ sub installed_perls {
         } else {
             $orig_version = `$executable -e 'print \$]'`;
             if ( defined $orig_version and length $orig_version ){
-                open my $fh, '>', $version_file;
-                print {$fh} $orig_version;
+                if (open my $fh, '>', $version_file ){
+                    print {$fh} $orig_version;
+		}
             }
         }
 


### PR DESCRIPTION
Trivial nit: If `$PERLBREW_ROOT/perls/perl-*.*.*/.version` is read-only (e.g., a root-owned, system-wide directory like `/opt/perlbrew`), don't try to write to it.
