### PR TITLE
set $ENV{SHELL} if it's missing

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -24,6 +24,10 @@ use Getopt::Long ();
 
 ### global variables
 
+# set $ENV{SHELL} to executable path of parent process (= shell) if it's missing
+# (e.g. if this script was executed by a daemon started with "service xxx start")
+$ENV{SHELL} ||= readlink joinpath("/proc", getppid, "exe");
+
 local $SIG{__DIE__} = sub {
     my $message = shift;
     warn $message;


### PR DESCRIPTION
In the rare case when $ENV{SHELL} is not set, perlbrew currently prints out:

> /opt/perlbrew/etc/bashrc: line 43: setenv: command not found.
> Use of uninitialized value in pattern match (m//) at /loader/0x23ff038/App/perlbrew.pm line 34.

This patch assumes that the parent process is a shell and sets $ENV{SHELL} to the path of it's executable.
