### PR TITLE
Fix to MANPATH

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2589,6 +2589,7 @@ function __perlbrew_set_path
     set -l MANPATH_WITHOUT_PERLBREW (perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_HOME}) < 0 } grep { index($_, $ENV{PERLBREW_ROOT}) < 0 } split/:/,qx(manpath 2> /dev/null);')
 
     if test -n "$PERLBREW_MANPATH"
+        set -l PERLBREW_MANPATH $PERLBREW_MANPATH":"
         set -x MANPATH {$PERLBREW_MANPATH}{$MANPATH_WITHOUT_PERLBREW}
     else
         set -x MANPATH $MANPATH_WITHOUT_PERLBREW


### PR DESCRIPTION
This is a fix for fish so that the MANPATH will be a
':' delimited string instead of an array (expands to
words separated by spaces).  If this is not colon-delimited,
then the /etc/manpath.config is not sourced, (and) man
may not use all of the paths in MANPATH when looking for files.
