### PR TITLE
Speed up bashrc startup

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2422,15 +2422,21 @@ __perlbrew_reinit() {
     __perlbrew_set_path
 }
 
+__perlbrew_purify () {
+    local path patharray outsep
+    IFS=: read -ra patharray <<< "$1"
+    for path in "${patharray[@]}" ; do
+        case "$path" in
+            *"$PERLBREW_HOME"*) ;;
+            *"$PERLBREW_ROOT"*) ;;
+            *) printf '%s' "$outsep$path" ; outsep=: ;;
+        esac
+    done
+}
+
 __perlbrew_set_path () {
-    MANPATH_WITHOUT_PERLBREW=`perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_HOME}) < 0 } grep { index($_, $ENV{PERLBREW_ROOT}) < 0 } split/:/,qx(manpath 2> /dev/null);'`
-    export MANPATH=$PERLBREW_MANPATH${PERLBREW_MANPATH:+:}$MANPATH_WITHOUT_PERLBREW
-    unset MANPATH_WITHOUT_PERLBREW
-
-    PATH_WITHOUT_PERLBREW=$(eval $perlbrew_command display-pristine-path)
-    export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$PATH_WITHOUT_PERLBREW
-    unset PATH_WITHOUT_PERLBREW
-
+    export MANPATH=$PERLBREW_MANPATH${PERLBREW_MANPATH:+:}$(__perlbrew_purify "$(manpath)")
+    export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify "$PATH")
     hash -r
 }
 


### PR DESCRIPTION
On my system (2GHz dual-core i7, SSD, MacOS 10.7) these patches more than halve the time it takes to source `~/perl5/perlbrew/etc/bashrc` (from ~0.18 sec down to ~0.08s). Other stuff in my `~/.bashrc` takes about 0.07s, so these patches reduce the delay for opening a new terminal window from ~0.25s (feels laggy; window takes a moment to come up) to ~0.15s (not quite instant, but feels much quicker).

And this is still a fairly hot machine, so I assume most users will benefit more than I do.

(Attacking the remainder of the startup time requires making App::perlbrew load and run quicker, which really means making local::lib load faster, which means that part is not so easy.)
