### PR TITLE
allow spaces in PATH elements

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2449,7 +2449,7 @@ __perlbrew_purify () {
     if [[ -n "$ZSH_VERSION" ]]; then
         IFS=: read -rA patharray <<< "$1"
     fi
-    for path in ${patharray[@]} ; do
+    for path in "${patharray[@]}" ; do
         case "$path" in
             (*"$PERLBREW_HOME"*) ;;
             (*"$PERLBREW_ROOT"*) ;;
@@ -2460,7 +2460,7 @@ __perlbrew_purify () {
 
 __perlbrew_set_path () {
     export MANPATH=$PERLBREW_MANPATH${PERLBREW_MANPATH:+:}$(__perlbrew_purify "$(manpath)")
-    export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify $PATH)
+    export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify "$PATH")
     hash -r
 }
 

--- a/perlbrew
+++ b/perlbrew
@@ -2460,7 +2460,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
       if [[ -n "$ZSH_VERSION" ]]; then
           IFS=: read -rA patharray <<< "$1"
       fi
-      for path in ${patharray[@]} ; do
+      for path in "${patharray[@]}" ; do
           case "$path" in
               (*"$PERLBREW_HOME"*) ;;
               (*"$PERLBREW_ROOT"*) ;;
@@ -2471,7 +2471,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
   
   __perlbrew_set_path () {
       export MANPATH=$PERLBREW_MANPATH${PERLBREW_MANPATH:+:}$(__perlbrew_purify "$(manpath)")
-      export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify $PATH)
+      export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify "$PATH")
       hash -r
   }
   


### PR DESCRIPTION
I have the following in my `PATH`: `/Applications/Android Studio.app/sdk/platform-tools`. Perlbrew 0.71 dealt with this just fine, but 0.72 chokes on the space in "Android Studio.app" and truncates the path at this point.

A judicious use of quotes fixes this.

There are no tests for the handling of weirdnesses in `PATH`, and I was unsure where best to add them. I've left that alone.
