### PR TITLE
Fix perlbrew.fish to allow execution of perlbrew use

### DIFF
--- a/perlbrew
+++ b/perlbrew
@@ -2638,7 +2638,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
   end
   
   function __perlbrew_set_env
-      set -l code (eval $perlbrew_command env $argv | perl -pe 's/export\s+(\S+)="(\S*)"/set -x $1 $2;/g; y/:/ /')
+      set -l code (eval $perlbrew_command env $argv | perl -pe 's/^(export|setenv)/set -xg/; s/^unset[env]*/set -eug/; s/$/;/; y/:/ /')
   
       if test -z "$code"
           return 0;
@@ -2716,7 +2716,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
   end
   
   function __source_init
-      perl -pe's/^export/set -x/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | . -
+      perl -pe's/^\(export|setenv\)/set -xg/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | . -
   end
   
   if test -z "$PERLBREW_ROOT"


### PR DESCRIPTION
Before this pull request perlbrew use perl-blah, would not change the current instance of perl in the shell. This pull request fixes the behaviour to work correctly.
