### PR TITLE
'perlbrew use' should not break the user's shell

### DIFF
--- a/perlbrew
+++ b/perlbrew
@@ -1711,9 +1711,6 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
   
           }
       }
-      elsif  ($shell =~ /\/bash$/)  {
-          $shell_opt = "--noprofile --norc";
-      }
   
       my %env = ($self->perlbrew_env($name), PERLBREW_SKIP_INIT => 1);
   


### PR DESCRIPTION
Starting bash subshells with --norc breaks the users shell setup and
seems unecessary. The --profile option is also unecessary since a
non-login shell is being started anyways.