### PR TITLE
usage help for command alias and lib reworked

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -428,7 +428,7 @@ status are not populated back.
 
 =head1 COMMAND: ENV
 
-Usage: perlbrew env <name>
+Usage: perlbrew env [ <name> ]
 
 Low-level command. Invoke this command to see the list of environment
 variables that are set by C<perlbrew> itself for shell integration.
@@ -444,7 +444,7 @@ tcsh / csh users should see 'setenv' statements instead of `export`.
 
 =head1 COMMAND: SYMLINK-EXECUTABLES
 
-Usage: perlbrew symlink-executables <name>
+Usage: perlbrew symlink-executables [ <name> ]
 
 Low-level command. This command is used to create the C<perl> executable
 symbolic link to, say, C<perl5.13.6>. This is only required for
@@ -526,7 +526,7 @@ Show the version of perlbrew.
 
 =head1 COMMAND: LIB
 
-Usage:
+Usage: perlbrew lib <action> <lib-name>
 
     perlbrew lib list
     perlbrew lib create <lib-name>

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -555,7 +555,7 @@ sub run_command_version {
 }
 
 sub run_command_help {
-    my ($self, $status, $verbose) = @_;
+    my ($self, $status, $verbose, $return_text) = @_;
 
     require Pod::Usage;
 
@@ -581,6 +581,7 @@ sub run_command_help {
                 $out = "Cannot find documentation for '$status'\n\n";
             }
 
+            return "\n$out" if ($return_text);
             print "\n$out";
             close $fh;
         }
@@ -2079,18 +2080,9 @@ sub run_command_clean {
 sub run_command_alias {
     my ($self, $cmd, $name, $alias) = @_;
 
-    if (!$cmd) {
-        print <<USAGE;
-
-Usage: perlbrew alias [-f] <action> <name> [<alias>]
-
-    perlbrew alias create <name> <alias>
-    perlbrew alias delete <alias>
-    perlbrew alias rename <old_alias> <new_alias>
-
-USAGE
-
-        return;
+    unless($cmd) {
+        $self->run_command_help("alias");
+        exit(-1);
     }
 
     my $path_name  = joinpath($self->root, "perls", $name);
@@ -2153,29 +2145,12 @@ sub run_command_display_installation_failure_message {
     my ($self) = @_;
 }
 
-sub lib_usage {
-    my $usage = <<'USAGE';
-
-Usage: perlbrew lib <action> <name> [<name> <name> ...]
-
-    perlbrew lib list
-    perlbrew lib create nobita
-    perlbrew lib create perl-5.14.2@nobita
-
-    perlbrew use perl-5.14.2@nobita
-    perlbrew lib delete perl-5.12.3@nobita shizuka
-
-USAGE
-
-
-    return $usage;
-}
-
 sub run_command_lib {
     my ($self, $subcommand, @args) = @_;
+
     unless ($subcommand) {
-        print lib_usage;
-        return;
+        $self->run_command_help("lib");
+        exit(-1);
     }
 
     my $sub = "run_command_lib_$subcommand";
@@ -2190,7 +2165,7 @@ sub run_command_lib {
 sub run_command_lib_create {
     my ($self, $name) = @_;
 
-    die "ERROR: No lib name\n", lib_usage unless $name;
+    die "ERROR: No lib name\n", $self->run_command_help("lib", undef, 'return_text') unless $name;
 
     $name =~ s/^/@/ unless $name =~ /@/;
 
@@ -2219,7 +2194,7 @@ sub run_command_lib_create {
 sub run_command_lib_delete {
     my ($self, $name) = @_;
 
-    die "ERROR: No lib to delete\n", lib_usage unless $name;
+    die "ERROR: No lib to delete\n", $self->run_command_help("lib", undef, 'return_text') unless $name;
 
     $name =~ s/^/@/ unless $name =~ /@/;
 

--- a/t/command-lib.t
+++ b/t/command-lib.t
@@ -16,11 +16,20 @@ mock_perlbrew_install("perl-5.14.2");
 mock_perlbrew_install("perl-5.14.3");
 
 describe "lib command," => sub {
-    it "shows a page of usage synopsis when no sub-command are given." => sub {
-        stdout_like {
-            App::perlbrew->new("lib")->run;
-
-        } qr/usage/i;
+    describe "when invoked with unknown action name,", sub {
+        it "should display error" => sub {
+            my $x   = "correcthorsebatterystaple";
+            my $app = App::perlbrew->new("lib", $x);
+            stdout_like {
+                eval {
+                    $app->run;
+                    1;
+                }
+                or do {
+                    print STDERR $@;
+                };
+            } qr/Unknown command: $x/;
+        }
     };
 
     describe "without lib name" => sub {


### PR DESCRIPTION
running "perlbrew alias" or "perlbrew lib" (with no action) would
display some inline usage help (some static string) while "perlbrew
alias help", "perlbrew help alias" or "perlbrew help lib" would display
the help (for the command) from the inline POD.

this is now changed so these two commands behave just like all others
wrt "perlbrew help <command>" or calling the command with no action. the
inline usage help was removed. the inline POD is now everywhere the only
source of documentation.