### PR TITLE
perlbrew use clobbers user's PERL5LIB prefix

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1627,6 +1627,13 @@ sub perlbrew_env {
 
             if (-d $base) {
                 $current_local_lib_context = $current_local_lib_context->activate($base);
+
+                if ( $self->env('PERLBREW_LIB_PREFIX') ) {
+                    unshift
+                        @{$current_local_lib_context->libs},
+                            $self->env('PERLBREW_LIB_PREFIX');
+                }
+
                 $env{PERLBREW_PATH}    = joinpath($base, "bin") . ":" . $env{PERLBREW_PATH};
                 $env{PERLBREW_MANPATH} = joinpath($base, "man") . ":" . $env{PERLBREW_MANPATH};
                 $env{PERLBREW_LIB}  = $lib_name;

--- a/t/command-env.t
+++ b/t/command-env.t
@@ -25,6 +25,7 @@ describe "env command," => sub {
         delete $ENV{PERL_LOCAL_LIB_ROOT};
         delete $ENV{PERLBREW_LIB};
         delete $ENV{PERL5LIB};
+        delete $ENV{PERLBREW_LIB_PREFIX};
     };
 
     describe "when invoked with a perl installation name,", sub {
@@ -55,6 +56,33 @@ OUT
                 $app->run;
             } <<"OUT";
 export PERL5LIB="$lib_dir/lib/perl5${PERL5LIB_maybe}"
+export PERLBREW_LIB="nobita"
+export PERLBREW_MANPATH="$lib_dir/man:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/man"
+export PERLBREW_PATH="$lib_dir/bin:$App::perlbrew::PERLBREW_ROOT/bin:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/bin"
+export PERLBREW_PERL="perl-5.14.1"
+export PERLBREW_ROOT="$App::perlbrew::PERLBREW_ROOT"
+export PERLBREW_VERSION="$App::perlbrew::VERSION"
+export PERL_LOCAL_LIB_ROOT="$lib_dir"
+export PERL_MB_OPT="--install_base "$lib_dir""
+export PERL_MM_OPT="INSTALL_BASE=$lib_dir"
+OUT
+        }
+    };
+
+    describe "when invoked with a perl installation name with lib name and PERLBREW_LIB_PREFIX set,", sub {
+        it "displays PERL5LIB with PERLBREW_LIB_PREFIX value first." => sub {
+            note 'perlbrew env perl-5.14.1@nobita';
+
+            $ENV{PERLBREW_LIB_PREFIX} = 'perlbrew_lib_prefix';
+
+            my $PERL5LIB_maybe = $ENV{PERL5LIB} ? ":\$PERL5LIB" : "";
+            my $app = App::perlbrew->new("env", 'perl-5.14.1@nobita');
+
+            my $lib_dir = "$App::perlbrew::PERLBREW_HOME/libs/perl-5.14.1\@nobita";
+            stdout_is {
+                $app->run;
+            } <<"OUT";
+export PERL5LIB="$ENV{PERLBREW_LIB_PREFIX}:$lib_dir/lib/perl5${PERL5LIB_maybe}"
 export PERLBREW_LIB="nobita"
 export PERLBREW_MANPATH="$lib_dir/man:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/man"
 export PERLBREW_PATH="$lib_dir/bin:$App::perlbrew::PERLBREW_ROOT/bin:$App::perlbrew::PERLBREW_ROOT/perls/perl-5.14.1/bin"


### PR DESCRIPTION
Sometimes users (i.e. me) always want a particular lib directory to take precedence in their `PERL5LIB`.  For example, I always like to have `./lib:` at the start of my `PERL5LIB` so if I'm in a repo doing development the local dev code is used over anything installed.

Right now when the `perlbrew use @some-local-lib` command runs it puts the local lib directory at the very start of my `PERL5LIB`, clobbering my custom prefix.

To make it possible for users to prevent certain lib directories from getting clobbered, this patch adds support for the `PERLBREW_LIB_PREFIX` env var which, if set, will always be pre-pended to the beginning of `PERL5LIB`.

I've also added a unit test for this functionality.

Thanks!

```
# Without patch
$ echo $PERL5LIB
lib
$ perlbrew use perl-5.20.1@tmp
$ echo $PERL5LIB
/home/calid/.perlbrew/libs/perl-5.20.1@tmp/lib/perl5:lib <== custom lib prefix clobbered :(

# With patch
$ export PERLBREW_LIB_PREFIX=lib
$ perlbrew use perl-5.20.1@tmp
$ echo $PERL5LIB
lib:/home/calid/.perlbrew/libs/perl-5.20.1@tmp/lib/perl5
^^ custom lib prefix preserved :)
```