### PR TITLE
quote libs dirs during globbing in case PERLBREW_HOME has spaces

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1548,7 +1548,7 @@ sub installed_perls {
 sub local_libs {
     my ($self, $perl_name) = @_;
 
-    my @libs = map { substr($_, length($PERLBREW_HOME) + 6) } <$PERLBREW_HOME/libs/*>;
+    my @libs = map { substr($_, length($PERLBREW_HOME) + 6) } <"$PERLBREW_HOME/libs/*">;
 
     if ($perl_name) {
         @libs = grep { /^$perl_name\@/ } @libs;


### PR DESCRIPTION
Globbing with an unquoted `$PERLBREW_HOME` var may cause failure to yield valid lib dirs if the var has spaces, e.g.:
```
jfoo@mac ~/dev/App-perlbrew $ echo $PERLBREW_HOME
/Volumes/Macintosh HD/Users/jfoo/.perlbrew
```