### PR TITLE
Fix minor typo in error message

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2889,7 +2889,7 @@ Installation process failed. To spot any issues, check
 
   $self->{log_file}
 
-If some perl tests failed and you still want install this distribution anyway,
+If some perl tests failed and you still want to install this distribution anyway,
 do:
 
   (cd $self->{dist_extracted_dir}; make install)


### PR DESCRIPTION
Installation failure shows the "still want install" message, this patch just adds the missing "to".