### PR TITLE
Fix minor grammatical error

### DIFF
--- a/perlbrew
+++ b/perlbrew
@@ -2900,7 +2900,7 @@ $fatpacked{"App/perlbrew.pm"} = <<'APP_PERLBREW';
   
     $self->{log_file}
   
-  If some perl tests failed and you still want install this distribution anyway,
+  If some perl tests failed and you still want to install this distribution anyway,
   do:
   
     (cd $self->{dist_extracted_dir}; make install)


### PR DESCRIPTION
This makes the informative output after tests have failed in a `perlbrew
install` step up agree with App/perlbrew.pm.