### PR TITLE
Update deprecated '.' command in fish script to 'source'.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2686,7 +2686,7 @@ function perlbrew
 end
 
 function __source_init
-    perl -pe's/^(export|setenv)/set -xg/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | . -
+    perl -pe's/^(export|setenv)/set -xg/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | source
 end
 
 if test -z "$PERLBREW_ROOT"


### PR DESCRIPTION
I was getting several errors when trying to source the `perlbrew.fish` file. It looks like the develop branch already had one of the fixes I put in place, so this pull request contains the other. It appears to be working for me now in fish 2.2.0.