### PR TITLE
Hard-code an abstract as "all_from" isn't working.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,6 +4,8 @@ license 'mit';
 
 all_from 'lib/App/perlbrew.pm';
 
+abstract 'App::perlbrew - Manage perl installations in your $HOME';
+
 repository 'git://github.com/gugod/App-perlbrew.git';
 
 requires


### PR DESCRIPTION
I got App::perlbrew in this month's Pull Request Challenge. I haven't had time to take on anything complex, but I hope this is helpful.

I noticed that you're missing a Kwalitee point on CPANTS as your META.yml is missing an abstract. I haven't been able to work out why 'all_from' isn't picking up the abstract, so I've added an 'abstract' key which fills in the correct value.