### PR TITLE
add option --no-patchperl to disable patchperl on demand

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -226,6 +226,8 @@ Options for C<install> command:
        --ld        Build perl with uselongdouble enabled
        --debug     Build perl with DEBUGGING enabled
        --clang     Build perl using the clang compiler
+       --no-patchperl
+                   Skip calling patchperl
 
     -D,-U,-A       Switches passed to perl Configure script.
                    ex. C<perlbrew install perl-5.10.1 -D usemymalloc -U versiononly>

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -337,6 +337,7 @@ sub parse_cmdline {
         'switch',
         'all',
         'shell=s',
+        'no-patchperl',
 
         # options passed directly to Configure
         'D=s@',
@@ -1355,8 +1356,8 @@ INSTALL
     my @preconfigure_commands = (
         "cd $dist_extracted_dir",
         "rm -f config.sh Policy.sh",
-        $patchperl,
     );
+    push @preconfigure_commands, $patchperl unless $self->{"no-patchperl"};
 
     my $configure_flags = $self->env("PERLBREW_CONFIGURE_FLAGS") || '-de';
 


### PR DESCRIPTION
The option added fixes #491 based on the discussions there. The option suppresses calling patchperl to avoid test failures for people to trying to build perl while their names aren't in the AUTHORS file(typical for new/first-time perl hackers).