### PR TITLE
Installation via sparrow perlbrew plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ The `self-upgrade` command will not upgrade the perlbrew installed by cpan
 command, but it is also easy to upgrade perlbrew by running `cpan App::perlbrew`
 again.
 
+### Installation via sparrow perlbrew plugin. 
+
+This method could be used for automation of perlbrew installation. 
+As it not only installs perlbrew but amend ~/.bash_profile file with `source ~/perl5/perlbrew/etc/bashrc`.
+
+    cpanm Sparrow
+    sparrow index update
+    sparrow plg install perlbrew
+    sparrow plg run perlbrew
+
+Follow [sparrow perlbrew](https://sparrowhub.org/info/perlbrew) for details.
+
 ## METHODS
 
 - (Str) current\_perl

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ again.
 ### Installation via sparrow perlbrew plugin
 
 This method could be used for automation of perlbrew installation. 
-As it not only installs perlbrew but amend `~/.bash_profile` file with `source ~/perl5/perlbrew/etc/bashrc` line.
+As it not only installs a perlbrew but amends `~/.bash_profile` file with `source ~/perl5/perlbrew/etc/bashrc` line
+and adds some trivial post deployment checks.
 
     cpanm Sparrow
     sparrow index update

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ The `self-upgrade` command will not upgrade the perlbrew installed by cpan
 command, but it is also easy to upgrade perlbrew by running `cpan App::perlbrew`
 again.
 
-### Installation via sparrow perlbrew plugin. 
+### Installation via sparrow perlbrew plugin
 
 This method could be used for automation of perlbrew installation. 
-As it not only installs perlbrew but amend ~/.bash_profile file with `source ~/perl5/perlbrew/etc/bashrc`.
+As it not only installs perlbrew but amend `~/.bash_profile` file with `source ~/perl5/perlbrew/etc/bashrc` line.
 
     cpanm Sparrow
     sparrow index update


### PR DESCRIPTION
HI @gugod ! I would like to share a perlbrew installation via sparrow perlbrew plugin. Right now it is just a simple wrapper around `\curl -L http://install.perlbrew.pl | bash` , but it also amends ~/.bash_profile file with `source ~/perl5/perlbrew/etc/bashrc` line  and adds some trivial post deployment checks, so this installation method could be used for automation of perlbrew installation. So if you like the idea, please accept this pull request or tell me if anything not clear and I will be happy to answer ...

Thanks!