### PR TITLE
Don't break when git's core.abbrev changes

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1151,7 +1151,7 @@ sub do_install_blead {
     opendir DIRH, $build_dir or die "Couldn't open ${build_dir}: $!";
     my @contents = readdir DIRH;
     closedir DIRH or warn "Couldn't close ${build_dir}: $!";
-    my @candidates = grep { m/^perl-[0-9a-f]{7,8}$/ } @contents;
+    my @candidates = grep { m/^perl-[0-9a-f]{4,40}$/ } @contents;
     # Use a Schwartzian Transform in case there are lots of dirs that
     # look like "perl-$SHA1", which is what's inside blead.tar.gz,
     # so we stat each one only once.

--- a/perlbrew
+++ b/perlbrew
@@ -1160,7 +1160,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
       opendir DIRH, $build_dir or die "Couldn't open ${build_dir}: $!";
       my @contents = readdir DIRH;
       closedir DIRH or warn "Couldn't close ${build_dir}: $!";
-      my @candidates = grep { m/^perl-[0-9a-f]{7,8}$/ } @contents;
+      my @candidates = grep { m/^perl-[0-9a-f]{4,40}$/ } @contents;
       # Use a Schwartzian Transform in case there are lots of dirs that
       # look like "perl-$SHA1", which is what's inside blead.tar.gz,
       # so we stat each one only once.


### PR DESCRIPTION
Snapshot filenames are of the form perl-$abbreviated_sha1.tar.gz, where
the length of the abbreviation can be anything between 4 and 40. In
newer gits this defaults to 10 for perl.git, but let's be future-proof
and accept all possible lengths.
