### PR TITLE
Available with urls

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -701,6 +701,7 @@ sub run_command_available {
 
     print "\n";
 
+    return reverse sort keys %$perls;
 }
 
 sub available_perls {

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -706,7 +706,8 @@ sub run_command_available {
 
 sub available_perls {
     my $perls = available_perls_with_urls( @_ );
-    return reverse sort keys %$perls;
+    return  reverse sort keys %$perls;
+
 }
 
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -681,7 +681,8 @@ sub run_command_available {
     my @installed = $self->installed_perls(@_);
 
     my $is_installed;
-    while(  my ( $available, $url ) = each %$perls ) {
+    for my $available ( reverse sort keys %$perls ){
+        my $url = $perls->{ $available };
         $is_installed = 0;
         for my $installed (@installed) {
             my $name = $installed->{name};
@@ -692,18 +693,19 @@ sub run_command_available {
             }
         }
 
-        print sprintf( "\n%1s %s\tURL: <%s>",
+        print sprintf( "\n%1s %12s      URL: <%s>",
                        $is_installed ? 'i' : '',
                        $available,
                        $url );
     }
 
     print "\n";
+
 }
 
 sub available_perls {
     my $perls = available_perls_with_urls( @_ );
-    return keys %$perls;
+    return reverse sort keys %$perls;
 }
 
 

--- a/t/03.test_get_available_versions.t
+++ b/t/03.test_get_available_versions.t
@@ -20,8 +20,8 @@ use App::perlbrew;
 plan tests => 9;
 
 my $app = App::perlbrew->new();
-
-is scalar $app->available_perls(), 8, "Correct number of releases found";
+my @vers = $app->available_perls();
+is scalar( @vers ), 8, "Correct number of releases found";
 
 my @known_perl_versions = (
     'perl-5.13.11', 'perl-5.12.3',  'perl-5.10.1',  'perl-5.8.9',
@@ -38,20 +38,20 @@ __DATA__
 <head>
     <title>Perl Source - www.cpan.org</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />    <link rel="author" href="mailto:cpan+linkrelauthor@perl.org" />
-	<link rel="canonical" href="http://www.cpan.org/src/index.html" />	
-	<link type="text/css" rel="stylesheet" href="../misc/css/cpan.css" /> 
-	
+	<link rel="canonical" href="http://www.cpan.org/src/index.html" />
+	<link type="text/css" rel="stylesheet" href="../misc/css/cpan.css" />
+
 </head>
 <body class="section_source">
 
 <table id="wrapper" border="0" width="95%" cellspacing="0" cellpadding="2" align="center">
     <tr>
         <td id="header">
-        	
+
 			<div id="header_left">
 				<a href="../index.html"><img src="../misc/images/cpan.png" id="logo" alt="CPAN" /></a>
      		</div>
-			
+
 			<div id="header_right">
 			  <h1>Comprehensive Perl Archive Network</h1>
               <p id="strapline">Stop reinventing wheels, start building space rockets
@@ -61,7 +61,7 @@ __DATA__
            </div>
         </td>
     </tr>
-    <tr> 
+    <tr>
         <td id="menubar_holder">
 
             <ul class="menubar">
@@ -72,7 +72,7 @@ __DATA__
                 <li><a href="../misc/cpan-faq.html">FAQ</a></li>
                 <li><a href="../SITES.html">Mirrors</a></li>
 			</ul>
-			
+
 			<div id="searchbar">
 				<form method="get" action="http://search.cpan.org/search" name="f" class="searchbox menubar" id="f">
 					<input type="hidden" name="mode" value="all" />
@@ -86,8 +86,8 @@ __DATA__
     <tr>
         <td>
             <div id="content">
-			
-            
+
+
 
 <h1>Perl Source</h1>
 
@@ -114,7 +114,7 @@ __DATA__
      make install
 </pre>
 <p>
-    Read both INSTALL and README.<strong>yoursystem</strong> in 
+    Read both INSTALL and README.<strong>yoursystem</strong> in
     the <code>perl-5.12.3</code> directory for more detailed information.
 </p>
 
@@ -462,18 +462,18 @@ __DATA__
         <td id="footer">
             <div id="footer_copyright">
                 <p>Yours Eclectically, The Self-Appointed Master Librarians (<i>OOK!</i>) of the CPAN.<br/>
-                   &copy; 1995-2010 Jarkko Hietaniemi.  
-                   &copy; 2011 <a href="http://www.perl.org">Perl.org</a>.  
-                   All rights reserved. 
+                   &copy; 1995-2010 Jarkko Hietaniemi.
+                   &copy; 2011 <a href="http://www.perl.org">Perl.org</a>.
+                   All rights reserved.
                    <a href="../disclaimer.html">Disclaimer</a>.
                 </p>
             </div>
 
-            
+
             <div id="footer_mirror">
 			<p>Master mirror hosted by <a href="http://www.yellowbot.com/"><img alt="YellowBot" src="../misc/images/yellowbot.png" /></a></p>
             </div>
-            
+
 
 
         </td>

--- a/t/command-available.t
+++ b/t/command-available.t
@@ -11,20 +11,54 @@ use App::perlbrew;
 $App::perlbrew::PERLBREW_ROOT = my $perlbrew_root = tempdir( CLEANUP => 1 );
 $App::perlbrew::PERLBREW_HOME = my $perlbrew_home = tempdir( CLEANUP => 1 );
 
+#
+# This is an example of availables perls on fluca1978 machine 2017-01-10.
+#
+my %available_perls = (
+    'perl5.005_04'      => 'http://www.cpan.org/src/5.0/perl5.005_04.tar.gz',
+    'perl5.004_05'      => 'http://www.cpan.org/src/5.0/perl5.004_05.tar.gz',
+    'perl-5.8.9'        => 'http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz',
+    'perl-5.6.2'        => 'http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz',
+    'perl-5.24.0'       => 'http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz',
+    'perl-5.22.2'       => 'http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz',
+    'perl-5.20.3'       => 'http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz',
+    'perl-5.18.4'       => 'http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz',
+    'perl-5.16.3'       => 'http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz',
+    'perl-5.14.4'       => 'http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz',
+    'perl-5.12.5'       => 'http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz',
+    'perl-5.10.1'       => 'http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz',
+    'cperl-5.25.2'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.25.2',
+    'cperl-5.25.1'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.25.1',
+    'cperl-5.24.2'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.24.2',
+    'cperl-5.24.1'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.24.1',
+    );
+
+
 describe "available command output, when nothing installed locally," => sub {
     it "should display a list of perl versions" => sub {
         my $app = App::perlbrew->new("available");
 
-        my @available_perls = qw(perl-5.14.1 perl-5.14.2 perl-5.12.4);
 
-        $app->expects("available_perls")->returns(@available_perls);
+        $app->expects( 'available_perls_with_urls' )->returns( \%available_perls );
 
-        stdout_is sub {
-            $app->run();
-        }, <<OUT
-  perl-5.14.1
-  perl-5.14.2
-  perl-5.12.4
+        stdout_is sub { $app->run(); }, <<OUT
+
+  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
+  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
+    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
+    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
+   perl-5.24.0      URL: <http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz>
+   perl-5.22.2      URL: <http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz>
+   perl-5.20.3      URL: <http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz>
+   perl-5.18.4      URL: <http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz>
+   perl-5.16.3      URL: <http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz>
+   perl-5.14.4      URL: <http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz>
+   perl-5.12.5      URL: <http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz>
+   perl-5.10.1      URL: <http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz>
+  cperl-5.25.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.2>
+  cperl-5.25.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.1>
+  cperl-5.24.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.2>
+  cperl-5.24.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.1>
 OUT
     };
 };
@@ -33,21 +67,33 @@ describe "available command output, when something installed locally," => sub {
     it "should display a list of perl versions, with markers on installed versions" => sub {
         my $app = App::perlbrew->new("available");
 
-        my @available_perls = qw(perl-5.14.1 perl-5.14.2 perl-5.12.4);
+
         my @installed_perls = (
-            { name => "perl-5.14.1" },
-            { name => "perl-5.14.2" }
+            { name => "perl-5.24.0" },
+            { name => "perl-5.20.3" }
         );
 
-        $app->expects("available_perls")->returns(@available_perls);
-        $app->expects("installed_perls")->returns(@installed_perls);
+         $app->expects( 'available_perls_with_urls' )->returns( \%available_perls );
+         $app->expects("installed_perls")->returns(@installed_perls);
 
-        stdout_is sub {
-            $app->run();
-        }, <<OUT
-i perl-5.14.1
-i perl-5.14.2
-  perl-5.12.4
+        stdout_is sub { $app->run(); }, <<OUT
+
+  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
+  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
+    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
+    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
+i  perl-5.24.0      URL: <http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz>
+   perl-5.22.2      URL: <http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz>
+i  perl-5.20.3      URL: <http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz>
+   perl-5.18.4      URL: <http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz>
+   perl-5.16.3      URL: <http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz>
+   perl-5.14.4      URL: <http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz>
+   perl-5.12.5      URL: <http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz>
+   perl-5.10.1      URL: <http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz>
+  cperl-5.25.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.2>
+  cperl-5.25.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.1>
+  cperl-5.24.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.2>
+  cperl-5.24.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.1>
 OUT
     };
 };


### PR DESCRIPTION
This is the second attempt, this time should work fine.
The idea is that the available command displays perl version along with URLs from which they are going to be downloaded.
The versions are sorted (an hash is used internally) and the tests have been modified to work with the new version.