### PR TITLE
Fix/bypass #525, update Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,19 +22,18 @@ requires
 
 test_requires
     'ExtUtils::MakeMaker'  => '6.86',
-    'File::Which'          => '1.21',
     'File::Temp'           => '0.2304',
+    'File::Which'          => '1.21',
     'IO::All'              => '0.51',
     'Path::Class'          => '0.33',
+    'Pod::Markdown'        => '2.002',
     'Test::Exception'      => '0.32',
     'Test::More'           => '1.001002',
     'Test::NoWarnings'     => '1.04',
     'Test::Output'         => '1.03',
     'Test::Simple'         => '1.001002',
-    'Test::Spec'           => '0.47';
-
-author_requires
-    'Pod::Markdown'        => '2.002';
+    'Test::Spec'           => '0.47',
+    'Test::Spec'           => '0.51';
 
 install_script 'bin/perlbrew';
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,8 +32,7 @@ test_requires
     'Test::NoWarnings'     => '1.04',
     'Test::Output'         => '1.03',
     'Test::Simple'         => '1.001002',
-    'Test::Spec'           => '0.47',
-    'Test::Spec'           => '0.51';
+    'Test::Spec'           => '0.47';
 
 install_script 'bin/perlbrew';
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -982,7 +982,7 @@ sub run_command_init {
         }
     }
 
-    my $root_dir = $self->path_with_tilde($self->root) . "/etc/";
+    my $root_dir = $self->path_with_tilde($self->root);
     # Skip this if we are running in a shell that already 'source's perlbrew.
     # This is true during a self-install/self-init.
     # Ref. https://github.com/gugod/App-perlbrew/issues/525
@@ -1020,9 +1020,9 @@ sub run_command_init {
         if ($self->home ne joinpath($self->env('HOME'), ".perlbrew")) {
             my $pb_home_dir = $self->path_with_tilde($self->home);
             if ( $shell =~ m/fish/ ) {
-                $code = "    set -x PERLBREW_HOME $pb_home_dir\n$code";
+                $code = "set -x PERLBREW_HOME $pb_home_dir\n    $code";
             } else {
-                $code = "    export PERLBREW_HOME=$pb_home_dir\n$code";
+                $code = "export PERLBREW_HOME=$pb_home_dir\n    $code";
             }
         }
 

--- a/t/installation-perlbrew.t
+++ b/t/installation-perlbrew.t
@@ -9,6 +9,7 @@ require 'test_helpers.pl';
 
 use Path::Class;
 use Test::More;
+use Capture::Tiny qw( capture_stdout );
 
 note "PERLBREW_ROOT set to $ENV{PERLBREW_ROOT}";
 
@@ -29,5 +30,47 @@ subtest "`perlbrew self-install` initialize the required dir structure under PER
     ok -f file($ENV{PERLBREW_ROOT}, "etc", "csh_set_path");
     ok -f file($ENV{PERLBREW_ROOT}, "etc", "csh_wrapper");
 };
+
+subtest "Works with bash", sub {
+    my $out = capture_stdout {
+        my $app = App::perlbrew->new('self-install');
+        $app->current_shell("bash");
+        $app->run;
+    };
+    like($out, qr|    export PERLBREW_HOME=\S+|);
+    like($out, qr|    source \S+/etc/bashrc|);
+};
+
+subtest "Works with fish", sub {
+    my $out = capture_stdout {
+        my $app = App::perlbrew->new('self-install');
+        $app->current_shell("fish");
+        $app->run;
+    };
+    like($out, qr|    set -x PERLBREW_HOME \S+|);
+    like($out, qr|    . \S+/etc/perlbrew.fish|);
+};
+
+subtest "Works with zsh", sub {
+    my $out = capture_stdout {
+        my $app = App::perlbrew->new('self-install');
+        $app->current_shell("zsh4");
+        $app->run;
+    };
+    like($out, qr|    export PERLBREW_HOME=\S+|);
+    like($out, qr|    source \S+/etc/bashrc|);
+};
+
+subtest "Exports PERLBREW_HOME when needed", sub {
+    my $out = capture_stdout {
+        local $App::perlbrew::PERLBREW_HOME = App::perlbrew::joinpath($ENV{HOME}, ".perlbrew");
+        my $app = App::perlbrew->new('self-install');
+        $app->current_shell("bash");
+        $app->run;
+    };
+    unlike($out, qr|PERLBREW_HOME=\S+|);
+    like($out, qr|    source \S+/etc/bashrc|);
+};
+
 
 done_testing;


### PR DESCRIPTION
This makes four non-trivial changes:

- Switches to use a single shell variable for "am I running a perlbrew `.rc` file?", regardless of what shell is being used.
- Suppresses full "welcome message" if that variable is set, e.g. during self-install or similar.
- Tries to be a little smarter about searching for `.rc` files to suggest appending to; if `.bash_profile` is absent but `.profile` is present, for example, the "welcome message" will suggest `.profile`. If no files are present, the current behavior will remain.
- Updates Makefile.PL with missing dependencies, needed to make/test on perlbrewed Perl 5.24.1 on OSX.

There are two drawbacks to these changes:
- If a user opens a shell which `source`s a perlbrew `.rc` file, deletes that file, and then installs Perlbrew in the same shell, the "welcome message" suggesting that they append a `source` line will not appear. IMO such users probably know what they're doing anyway.
- These changes won't take effect on the first `self-install` or `self-upgrade` after pulling down these changes; instead they will take effect on all subsequent self-* operations.

All tests pass for me, and a simple test of self-upgrading doesn't post the offending notice. I am not super-familiar with this codebase, though, so there's a good change I did something stupid/missed something obvious.

Please consider/comment.

Thanks for making a great product!