### PR TITLE
Sort the available Perl version from the newest to the oldest.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1786,10 +1786,11 @@ sub installed_perls {
             libs => [ $self->local_libs($name) ],
             executable  => $executable,
             dir => $installation_dir,
+            comparable_version => $self->comparable_perl_version( $orig_version ),
         };
     }
 
-    return sort { $a->{orig_version} <=> $b->{orig_version} or $a->{name} cmp $b->{name}  } @result;
+    return sort { $b->{comparable_version} <=> $a->{comparable_version} or $a->{name} cmp $b->{name}  } @result;
 }
 
 sub local_libs {

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -696,6 +696,17 @@ sub comparable_perl_version {
     }
 }
 
+# Internal method.
+# Performs a comparable sort of the perl versions specified as
+# list.
+sub sort_perl_versions {
+    my ( $self, @perls ) = @_;
+    return map { $_->[ 0 ] }
+           sort { $b->[ 1 ] cmp $a->[ 1 ] }
+           map { [ $_, $self->comparable_perl_version( $_ ) ] }
+           @perls;
+}
+
 sub run_command_available {
     my ( $self, $dist, $opts ) = @_;
 
@@ -705,10 +716,7 @@ sub run_command_available {
     my $is_installed;
 
     # sort the keys of Perl installation (Randal to the rescue!)
-    my @sorted_perls = map { $_->[ 0 ] }
-    sort { $b->[ 1 ] cmp $a->[ 1 ] }
-    map { [ $_, $self->comparable_perl_version( $_ ) ] }
-    keys %$perls;
+    my @sorted_perls = $self->sort_perl_versions( keys %$perls );
 
     for my $available ( @sorted_perls ){
         my $url = $perls->{ $available };
@@ -730,16 +738,13 @@ sub run_command_available {
 
     print "\n";
 
-    return reverse sort keys %$perls;
+    return @sorted_perls;
 }
 
 sub available_perls {
-    my $perls = available_perls_with_urls( @_ );
-    # sort the keys of Perl installation (Randal to the rescue!)
-    return map { $_->[ 0 ] }
-           sort { $b->[ 1 ] cmp $a->[ 1 ] }
-           map { [ $_, $self->comparable_perl_version( $_ ) ] }
-           keys %$perls;
+    my ( $self ) = @_;
+    my $perls    = $self->available_perls_with_urls;
+    return $self->sort_perl_versions( keys %$perls );
 }
 
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -735,8 +735,11 @@ sub run_command_available {
 
 sub available_perls {
     my $perls = available_perls_with_urls( @_ );
-    return  reverse sort keys %$perls;
-
+    # sort the keys of Perl installation (Randal to the rescue!)
+    return map { $_->[ 0 ] }
+           sort { $b->[ 1 ] cmp $a->[ 1 ] }
+           map { [ $_, $self->comparable_perl_version( $_ ) ] }
+           keys %$perls;
 }
 
 
@@ -780,6 +783,9 @@ sub available_perls_with_urls {
             warn "\nWARN: Unable to retrieve the list of cperl releases.\n\n";
         }
     }
+
+
+
 
     return $perls;
 }

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1566,8 +1566,8 @@ sub do_install_this {
 
     push @d_options, "usecperl" if $looks_like_we_are_installing_cperl;
 
-    my $version = perl_version_to_integer($dist_version);
-    if (defined $version and $version < perl_version_to_integer( '5.6.0' ) ) {
+    my $version = $self->comparable_perl_version( $dist_version );
+    if (defined $version and $version < $self->comparable_perl_version( '5.6.0' ) ) {
         # ancient perls do not support -A for Configure
         @a_options = ();
     } else {
@@ -1599,7 +1599,7 @@ INSTALL
                 ( map { qq{'-U$_'} } @u_options ),
                 ( map { qq{'-A$_'} } @a_options ),
             ),
-        (defined $version and $version < perl_version_to_integer( '5.8.9' ))
+        (defined $version and $version < $self->comparable_perl_version( '5.8.9' ))
                 ? ("$^X -i -nle 'print unless /command-line/' makefile x2p/makefile")
                 : ()
     );

--- a/t/command-available.t
+++ b/t/command-available.t
@@ -12,25 +12,25 @@ $App::perlbrew::PERLBREW_ROOT = my $perlbrew_root = tempdir( CLEANUP => 1 );
 $App::perlbrew::PERLBREW_HOME = my $perlbrew_home = tempdir( CLEANUP => 1 );
 
 #
-# This is an example of availables perls on fluca1978 machine 2017-01-10.
+# This is an example of availables perls on fluca1978 machine 2017-10-05.
 #
 my %available_perls = (
-    'perl5.005_04'      => 'http://www.cpan.org/src/5.0/perl5.005_04.tar.gz',
-    'perl5.004_05'      => 'http://www.cpan.org/src/5.0/perl5.004_05.tar.gz',
-    'perl-5.8.9'        => 'http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz',
-    'perl-5.6.2'        => 'http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz',
-    'perl-5.24.0'       => 'http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz',
-    'perl-5.22.2'       => 'http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz',
-    'perl-5.20.3'       => 'http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz',
-    'perl-5.18.4'       => 'http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz',
-    'perl-5.16.3'       => 'http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz',
-    'perl-5.14.4'       => 'http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz',
-    'perl-5.12.5'       => 'http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz',
-    'perl-5.10.1'       => 'http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz',
-    'cperl-5.25.2'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.25.2',
-    'cperl-5.25.1'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.25.1',
-    'cperl-5.24.2'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.24.2',
-    'cperl-5.24.1'      => 'https://github.com//perl11/cperl/releases/download/cperl-5.24.1',
+   'perl-5.27.4'      => 'http://www.cpan.org/src/5.0/perl-5.27.4.tar.gz',
+   'perl-5.26.1'      => 'http://www.cpan.org/src/5.0/perl-5.26.1.tar.gz',
+   'perl-5.24.3'      => 'http://www.cpan.org/src/5.0/perl-5.24.3.tar.gz',
+   'perl-5.22.4'      => 'http://www.cpan.org/src/5.0/perl-5.22.4.tar.gz',
+   'perl-5.20.3'      => 'http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz',
+   'perl-5.18.4'      => 'http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz',
+   'perl-5.16.3'      => 'http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz',
+   'perl-5.14.4'      => 'http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz',
+   'perl-5.12.5'      => 'http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz',
+   'perl-5.10.1'      => 'http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz',
+    'perl-5.8.9'      => 'http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz',
+    'perl-5.6.2'      => 'http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz',
+  'perl5.005_04'      => 'http://www.cpan.org/src/5.0/perl5.005_04.tar.gz',
+  'perl5.004_05'      => 'http://www.cpan.org/src/5.0/perl5.004_05.tar.gz',
+  'cperl-5.26.1'      => 'https://github.com/perl11/cperl/archive/cperl-5.26.1.tar.gz',
+  'cperl-5.27.1'      => 'https://github.com/perl11/cperl/archive/cperl-5.27.1.tar.gz',
     );
 
 
@@ -43,22 +43,22 @@ describe "available command output, when nothing installed locally," => sub {
 
         stdout_is sub { $app->run(); }, <<OUT
 
-  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
-  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
-    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
-    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
-   perl-5.24.0      URL: <http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz>
-   perl-5.22.2      URL: <http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz>
+   perl-5.27.4      URL: <http://www.cpan.org/src/5.0/perl-5.27.4.tar.gz>
+   perl-5.26.1      URL: <http://www.cpan.org/src/5.0/perl-5.26.1.tar.gz>
+   perl-5.24.3      URL: <http://www.cpan.org/src/5.0/perl-5.24.3.tar.gz>
+   perl-5.22.4      URL: <http://www.cpan.org/src/5.0/perl-5.22.4.tar.gz>
    perl-5.20.3      URL: <http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz>
    perl-5.18.4      URL: <http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz>
    perl-5.16.3      URL: <http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz>
    perl-5.14.4      URL: <http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz>
    perl-5.12.5      URL: <http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz>
    perl-5.10.1      URL: <http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz>
-  cperl-5.25.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.2>
-  cperl-5.25.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.1>
-  cperl-5.24.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.2>
-  cperl-5.24.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.1>
+    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
+    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
+  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
+  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
+  cperl-5.26.1      URL: <https://github.com/perl11/cperl/archive/cperl-5.26.1.tar.gz>
+  cperl-5.27.1      URL: <https://github.com/perl11/cperl/archive/cperl-5.27.1.tar.gz>
 OUT
     };
 };
@@ -78,22 +78,22 @@ describe "available command output, when something installed locally," => sub {
 
         stdout_is sub { $app->run(); }, <<OUT
 
-  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
-  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
-    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
-    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
-i  perl-5.24.0      URL: <http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz>
-   perl-5.22.2      URL: <http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz>
+   perl-5.27.4      URL: <http://www.cpan.org/src/5.0/perl-5.27.4.tar.gz>
+   perl-5.26.1      URL: <http://www.cpan.org/src/5.0/perl-5.26.1.tar.gz>
+   perl-5.24.3      URL: <http://www.cpan.org/src/5.0/perl-5.24.3.tar.gz>
+   perl-5.22.4      URL: <http://www.cpan.org/src/5.0/perl-5.22.4.tar.gz>
 i  perl-5.20.3      URL: <http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz>
    perl-5.18.4      URL: <http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz>
    perl-5.16.3      URL: <http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz>
    perl-5.14.4      URL: <http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz>
    perl-5.12.5      URL: <http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz>
    perl-5.10.1      URL: <http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz>
-  cperl-5.25.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.2>
-  cperl-5.25.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.1>
-  cperl-5.24.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.2>
-  cperl-5.24.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.1>
+    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
+    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
+  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
+  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
+  cperl-5.26.1      URL: <https://github.com/perl11/cperl/archive/cperl-5.26.1.tar.gz>
+  cperl-5.27.1      URL: <https://github.com/perl11/cperl/archive/cperl-5.27.1.tar.gz>
 OUT
     };
 };

--- a/t/command-list.t
+++ b/t/command-list.t
@@ -41,10 +41,10 @@ describe "list command," => sub {
             $out =~ s/\n\n+/\n/;
 
             is $out, <<"EOF";
-* perl-5.12.3
-  perl-5.12.4
-  perl-5.14.1
   perl-5.14.2
+  perl-5.14.1
+  perl-5.12.4
+* perl-5.12.3
 EOF
         };
     };
@@ -68,12 +68,12 @@ EOF
             $out =~ s/\n\n+/\n/;
 
             is $out, <<'OUT';
+  perl-5.14.2
+  perl-5.14.1
+  perl-5.12.4
 * perl-5.12.3
   perl-5.12.3@nobita
   perl-5.12.3@shizuka
-  perl-5.12.4
-  perl-5.14.1
-  perl-5.14.2
 OUT
         };
 
@@ -86,12 +86,12 @@ OUT
             $out =~ s/\n\n+/\n/;
 
             is $out, <<'OUT';
+  perl-5.14.2
+  perl-5.14.1
+  perl-5.12.4
   perl-5.12.3
 * perl-5.12.3@nobita
   perl-5.12.3@shizuka
-  perl-5.12.4
-  perl-5.14.1
-  perl-5.14.2
 OUT
 
         };
@@ -99,4 +99,3 @@ OUT
 };
 
 runtests unless caller;
-


### PR DESCRIPTION
In the 'available' command it is annoying to have the available Perl list
with the oldest versions on top of the screen and the last on the bottom.
Users are going to install newer versions most of the time, so their first
choices should be the newest version, and therefore they should be available
on the top of list.
The problem is oldest version did not follow a coherent version numbering,
and therefore it is required to mangle the version number in order to make
it comparable.

In this implementation I transform a Perl version into a comparable string,
so that for instance v5.24.1 becomes 50_024_001, and so it can be
sorted quite easily with a Schwartzian-transform.

In order to keep 'Perl' separated from 'cperl', the latter version number
is translated into a string with no 10 factor multiplier on the
major version number.