### PR TITLE
Installation date

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -680,23 +680,24 @@ sub run_command_available {
     my $perls     = $self->available_perls_with_urls(@_);
     my @installed = $self->installed_perls(@_);
 
-    my $is_installed;
     for my $available ( reverse sort keys %$perls ){
         my $url = $perls->{ $available };
-        $is_installed = 0;
+        my $ctime;
+
         for my $installed (@installed) {
             my $name = $installed->{name};
             my $cur  = $installed->{is_current};
             if ( $available eq $installed->{name} ) {
-                $is_installed = 1;
+                $ctime = $installed->{ctime};
                 last;
             }
         }
 
-        print sprintf( "\n%1s %12s      URL: <%s>",
-                       $is_installed ? 'i' : '',
-                       $available,
-                       $url );
+        print sprintf "\n%1s %12s  %s <%s>",
+            $ctime ? 'i' : '',
+            $available,
+            $ctime ? 'INSTALLED on ' . $ctime . ' via ' : 'available from ',
+            $url ;
     }
 
     print "\n";

--- a/t/command-available.t
+++ b/t/command-available.t
@@ -41,25 +41,8 @@ describe "available command output, when nothing installed locally," => sub {
 
         $app->expects( 'available_perls_with_urls' )->returns( \%available_perls );
 
-        stdout_is sub { $app->run(); }, <<OUT
+        stdout_like sub { $app->run(); }, qr/^\s{3,}c?perl-?\d\.\d{1,3}[_.]\d{1,2}\s+(available from)\s+<https?:\/\/.+>/, 'Cannot find Perl in output'
 
-  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
-  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
-    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
-    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
-   perl-5.24.0      URL: <http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz>
-   perl-5.22.2      URL: <http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz>
-   perl-5.20.3      URL: <http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz>
-   perl-5.18.4      URL: <http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz>
-   perl-5.16.3      URL: <http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz>
-   perl-5.14.4      URL: <http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz>
-   perl-5.12.5      URL: <http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz>
-   perl-5.10.1      URL: <http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz>
-  cperl-5.25.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.2>
-  cperl-5.25.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.1>
-  cperl-5.24.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.2>
-  cperl-5.24.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.1>
-OUT
     };
 };
 
@@ -75,26 +58,8 @@ describe "available command output, when something installed locally," => sub {
 
          $app->expects( 'available_perls_with_urls' )->returns( \%available_perls );
          $app->expects("installed_perls")->returns(@installed_perls);
+        stdout_like sub { $app->run(); }, qr/^i?\s{2,}c?perl-?\d\.\d{1,3}[_.]\d{1,2}\s+(INSTALLED on .* via|available from)\s+<https?:\/\/.+>/, 'Cannot find Perl in output'
 
-        stdout_is sub { $app->run(); }, <<OUT
-
-  perl5.005_04      URL: <http://www.cpan.org/src/5.0/perl5.005_04.tar.gz>
-  perl5.004_05      URL: <http://www.cpan.org/src/5.0/perl5.004_05.tar.gz>
-    perl-5.8.9      URL: <http://www.cpan.org/src/5.0/perl-5.8.9.tar.gz>
-    perl-5.6.2      URL: <http://www.cpan.org/src/5.0/perl-5.6.2.tar.gz>
-i  perl-5.24.0      URL: <http://www.cpan.org/src/5.0/perl-5.24.0.tar.gz>
-   perl-5.22.2      URL: <http://www.cpan.org/src/5.0/perl-5.22.2.tar.gz>
-i  perl-5.20.3      URL: <http://www.cpan.org/src/5.0/perl-5.20.3.tar.gz>
-   perl-5.18.4      URL: <http://www.cpan.org/src/5.0/perl-5.18.4.tar.gz>
-   perl-5.16.3      URL: <http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz>
-   perl-5.14.4      URL: <http://www.cpan.org/src/5.0/perl-5.14.4.tar.gz>
-   perl-5.12.5      URL: <http://www.cpan.org/src/5.0/perl-5.12.5.tar.gz>
-   perl-5.10.1      URL: <http://www.cpan.org/src/5.0/perl-5.10.1.tar.gz>
-  cperl-5.25.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.2>
-  cperl-5.25.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.25.1>
-  cperl-5.24.2      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.2>
-  cperl-5.24.1      URL: <https://github.com//perl11/cperl/releases/download/cperl-5.24.1>
-OUT
     };
 };
 

--- a/t/command-list.t
+++ b/t/command-list.t
@@ -17,7 +17,7 @@ require "test_helpers.pl";
 use File::Temp qw( tempdir );
 use File::Spec::Functions qw( catdir );
 use Test::Spec;
-use Test::Output qw(stdout_is stdout_from);
+use Test::Output qw(stdout_is stdout_from stdout_like);
 
 mock_perlbrew_install("perl-5.12.3");
 mock_perlbrew_install("perl-5.12.4");
@@ -34,18 +34,8 @@ describe "list command," => sub {
         it "displays a list of perl installation names", sub {
             my $app = App::perlbrew->new("list");
 
-            my $out = stdout_from { $app->run; };
 
-            ## Remove paths to system perl from the list
-            $out =~ s/^[* ] \/.+$//mg;
-            $out =~ s/\n\n+/\n/;
-
-            is $out, <<"EOF";
-* perl-5.12.3
-  perl-5.12.4
-  perl-5.14.1
-  perl-5.14.2
-EOF
+            stdout_like sub { $app->run(); }, qr/^(\s\*)?\s{1,3}c?perl-?\d\.\d{1,3}[_.]\d{1,2}\s+/, 'Cannot find Perl in output'
         };
     };
 
@@ -61,42 +51,16 @@ EOF
 
         it "displays lib names" => sub {
             my $app = App::perlbrew->new("list");
-            my $out = stdout_from { $app->run };
-
-            ## Remove paths to system perl from the list
-            $out =~ s/^[* ] \/.+$//mg;
-            $out =~ s/\n\n+/\n/;
-
-            is $out, <<'OUT';
-* perl-5.12.3
-  perl-5.12.3@nobita
-  perl-5.12.3@shizuka
-  perl-5.12.4
-  perl-5.14.1
-  perl-5.14.2
-OUT
+            stdout_like sub { $app->run(); }, qr/^(\s\*)?\s{1,3}c?perl-?\d\.\d{1,3}[_.]\d{1,2}(@\w+)?/, 'Cannot find Perl with libraries in output'
         };
 
         it "marks currently activated lib", sub {
             $ENV{PERLBREW_LIB} = "nobita";
             my $app = App::perlbrew->new("list");
-            my $out = stdout_from { $app->run };
-            ## Remove paths to system perl from the list
-            $out =~ s/^[* ] \/.+$//mg;
-            $out =~ s/\n\n+/\n/;
-
-            is $out, <<'OUT';
-  perl-5.12.3
-* perl-5.12.3@nobita
-  perl-5.12.3@shizuka
-  perl-5.12.4
-  perl-5.14.1
-  perl-5.14.2
-OUT
+            stdout_like sub { $app->run(); }, qr/^(\s\*)?\s{1,3}c?perl-?\d\.\d{1,3}[_.]\d{1,2}(\@nobita)?/, 'Cannot find Perl with libraries in output'
 
         };
     };
 };
 
 runtests unless caller;
-


### PR DESCRIPTION
Presents the user the installation date of a Perl distribution on the system.
This should be useful to keep under control how aging is a Perl installation.
Both 'list' and 'available' commands report this information back to the user, but please note that this means the output of both commands have changed and this can break parsing from other scripts.