### PR TITLE
Bash profile

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -969,6 +969,18 @@ sub run_command_init {
     }
 
 
+    # special case: for bash and zsh it could be that ~/.profile
+    # is in place, so use it instead of a specific file
+    if ($self->current_shell =~ /(ba|z)?sh/) {
+        for my $found_yourshrc ( map { joinpath( $self->env('HOME'), ".$_" ) } ( $yourshrc, qq/profile/ ) ){
+            if ( -f $found_yourshrc ){
+                $yourshrc = $found_yourshrc;
+                last;
+            }
+        }
+
+    }
+
     my $root_dir = $self->path_with_tilde($self->root);
     my $pb_home_dir = $self->path_with_tilde($self->home);
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -954,7 +954,7 @@ sub run_command_init {
         }
     }
 
-    my ( $shrc, $yourshrc );
+    my ( $shrc, $yourshrc ) = ( 'bashrc', 'bash_profile' ); # default to bash
     if ( $self->current_shell =~ m/(t?csh)/ ) {
         $shrc     = 'cshrc';
         $yourshrc = $1 . "rc";
@@ -967,10 +967,7 @@ sub run_command_init {
         $shrc = "perlbrew.fish";
         $yourshrc = 'config/fish/config.fish';
     }
-    else {
-        $shrc = "bashrc";
-        $yourshrc = "bash_profile";
-    }
+
 
     my $root_dir = $self->path_with_tilde($self->root);
     my $pb_home_dir = $self->path_with_tilde($self->home);


### PR DESCRIPTION
Should fix #563
The idea is that for bash (and zsh) we need to test if ~/.profile exists before suggesting using specific shell initialization file.