### PR TITLE
Keep options '--force' and '--yes' coherent across commands.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -485,6 +485,10 @@ sub run {
 
 sub args {
     my ( $self ) = @_;
+
+    # keep 'force' and 'yes' coherent across commands
+    $self->{force} = $self->{yes} = 1 if ( $self->{force} || $self->{yes} );
+
     return @{ $self->{args} };
 }
 


### PR DESCRIPTION
Fix #539 (partially).
There are command that accept the '--force' option and others that
accept the '--yes' command (particularly those that interact with
external modules or utilities). With this simple fix each time either
'yes' or 'force' has been enabled the other is enabled too, so to keep
the code untouched and the options coherent.