### PR TITLE
Sort with reverse option

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1878,7 +1878,9 @@ sub installed_perls {
         };
     }
 
-    return sort { $b->{comparable_version} <=> $a->{comparable_version} or $a->{name} cmp $b->{name}  } @result;
+    return sort { ( $self->{reverse}
+                  ? ( $a->{comparable_version} <=> $b->{comparable_version} or $b->{name} cmp $a->{name} )
+                  : ( $b->{comparable_version} <=> $a->{comparable_version} or $a->{name} cmp $b->{name} ) )   } @result;
 }
 
 sub local_libs {

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -94,6 +94,7 @@ for (@flavors) {
     }
 }
 
+
 ### functions
 
 sub joinpath { join "/", @_ }
@@ -299,6 +300,7 @@ sub new {
         variation => '',
         both => [],
         append => '',
+        reverse => 0,
     );
 
     $opt{$_} = '' for keys %flavor;
@@ -340,6 +342,7 @@ sub parse_cmdline {
 
         'yes',
         'force|f',
+        'reverse',
         'notest|n',
         'quiet|q',
         'verbose|v',
@@ -352,6 +355,7 @@ sub parse_cmdline {
         'all',
         'shell=s',
         'no-patchperl',
+
 
         # options passed directly to Configure
         'D=s@',
@@ -369,6 +373,7 @@ sub parse_cmdline {
         'all-variations',
         'common-variations',
         @f,
+
 
         @ext
     )
@@ -752,8 +757,11 @@ sub comparable_perl_version {
 # list.
 sub sort_perl_versions {
     my ( $self, @perls ) = @_;
+
     return map { $_->[ 0 ] }
-           sort { $b->[ 1 ] <=> $a->[ 1 ] }
+    sort { (  $self->{reverse}
+            ? $a->[ 1 ] <=> $b->[ 1 ]
+            : $b->[ 1 ] <=> $a->[ 1 ] ) }
            map { [ $_, $self->comparable_perl_version( $_ ) ] }
            @perls;
 }

--- a/perlbrew
+++ b/perlbrew
@@ -6474,7 +6474,7 @@ Without a parameter, shows the version of perl currently selected.
 
 =head1 COMMAND: LIST
 
-Usage: perlbrew list
+Usage: perlbrew list [--reverse]
 
 List all perl installations inside perlbrew root specified by C<$PERLBREW_ROOT>
 environment variable. By default, the value is C<~/perl5/perlbrew>.
@@ -6483,9 +6483,11 @@ If there are libs associated to some perl installations, they will be included
 as part of the name. The output items in this list can be the argument in
 various other commands.
 
+With the C<reverse> option the sorting output is the opposite of the default one.
+
 =head1 COMMAND: AVAILABLE
 
-Usage: perlbrew available [--all]
+Usage: perlbrew available [--all] [--reverse]
 
 List the recently available versions of perl on CPAN.
 
@@ -6493,6 +6495,8 @@ The list is retrieved from the web page L<http://www.cpan.org/src/README.html>,
 and is not the list of *all* perl versions ever released in the past.
 
 To get a list of all perls ever released, use the C<--all> option.
+
+With the C<reverse> option the sorting output is the opposite of the default one.
 
 NOTICE: This command might be gone in the future and becomes an option of 'list' command.
 


### PR DESCRIPTION
The output of both 'list' and 'available' commands now reports the most recent versions on the top (due to my accepted PR). Issue #574  dislikes this, so I added the special option --reverse to both commands to make both behaviors available at users' wills.

The '--reverse' option is generally available thru the object instance as 'reverse' variable, because this allows for coherence against commands and could be useful for further commands.