### PR TITLE
Use gtar on AIX systems

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1245,7 +1245,7 @@ sub do_extract_tarball {
     # Was broken on Solaris, where GNU tar is probably
     # installed as 'gtar' - RT #61042
     my $tarx =
-        ($^O eq 'solaris' ? 'gtar ' : 'tar ') .
+        ($^O =~ /solaris|aix/ ? 'gtar ' : 'tar ') .
         ( $dist_tarball =~ m/xz$/  ? 'xJf' :
           $dist_tarball =~ m/bz2$/ ? 'xjf' : 'xzf' );
 


### PR DESCRIPTION
Like Solaris, AIX has its own tar, hence in order to unpack .bz2
archives one needs to use `gtar`.

I've tested this on an AIX system.  This patch might fix part of the problem mentioned in #227.