### PR TITLE
Since Perl 5.28 stash entry can point to a CV

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -518,7 +518,8 @@ sub commands {
     foreach my $sym (keys %$symtable) {
         if($sym =~ /^run_command_/) {
             my $glob = $symtable->{$sym};
-            if(defined *$glob{CODE}) {
+            if ( ref($glob) eq 'CODE' || defined *$glob{CODE} ) {
+                # with perl >= 5.27 stash entry can points to a CV directly
                 $sym =~ s/^run_command_//;
                 $sym =~ s/_/-/g;
                 push @commands, $sym;


### PR DESCRIPTION
Adjust the GV check in App::perlbrew::commands
to adjust it for perl later than 5.28.

A stash entry can be a GV or a CV.

Note: we could only enable this test for perl >= 5.27
but I do not think it worth the complexity.

References: RT #132483
Upstream-URL: https://rt.perl.org/SelfService/Display.html?id=132483