### PR TITLE
Remove extra '.' in shell rc append instructions

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1144,7 +1144,7 @@ sub run_command_init {
 
 perlbrew root ($root_dir) is initialized.
 
-Append the following piece of code to the end of your ~/.${yourshrc} and start a
+Append the following piece of code to the end of your ~/${yourshrc} and start a
 new shell, perlbrew should be up and fully functional from there:
 
     $code


### PR DESCRIPTION
The variable `${yourshrc}` already contains the '.' for the filename, adding the dot again in the append instructions gives too many dots.  For instance, if `${yourshrc}` contains `.profile`, then the append instructions would show `~/..profile` which isn't correct.  This change removes the extra dot and hopefully doesn't break things for shell rc files for other operating systems.

This PR is submitted in the hope that it is useful.  If you have any questions or comments concerning it, please don't hesitate to contact me and I can change things if necessary and resubmit.