### PR TITLE
Minor improvements and testing coverage increase

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -563,7 +563,7 @@ sub find_similar_commands {
     return @commands;
 }
 
-# This mehtod is called in the 'run' loop
+# This method is called in the 'run' loop
 # and executes every specific action depending
 # on the type of command.
 #
@@ -1288,7 +1288,7 @@ sub do_extract_tarball {
     return $extracted_dir;
 }
 
-# Searchs for directories inside a extracted tarball downloaded as perl "blead"
+# Search for directories inside a extracted tarball downloaded as perl "blead"
 # Use a Schwartzian Transform in case there are lots of dirs that
 # look like "perl-$SHA1", which is what's inside blead.tar.gz,
 # so we stat each one only once, ordering (descending )the directories per mtime

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -105,7 +105,11 @@ sub joinpath {
     return join "/", @_;
 }
 
-sub splitpath { split "/", $_[0] }
+sub splitpath {
+    my $path = shift;
+    die 'Cannot receive an undefined path as parameter' unless(defined($path));
+    split "/", $path;
+}
 
 sub mkpath {
     require File::Path;

--- a/t/current_shell.t
+++ b/t/current_shell.t
@@ -1,0 +1,23 @@
+use warnings;
+use strict;
+use Test::More tests => 6;
+use App::perlbrew;
+
+my $current_shell = (split("/", $ENV{SHELL}))[-1];
+my $self = App::perlbrew->new();
+is($self->current_shell(), $current_shell, 'current_shell gives the expected shell based on $SHELL environment variable') or diag("\$SHELL = $ENV{SHELL}");
+is($self->current_shell('foobar'), 'foobar', 'current_shell setups and returns anything passed as parameter');
+
+for my $shell (qw(bash zsh)) {
+    note("Testing with $shell");
+    $self->current_shell($shell);
+    ok($self->current_shell_is_bashish(), 'current_shell_is_bashish() returns true if the current shell is Bash or based on it');
+}
+
+
+for my $shell (qw(ksh sh)) {
+    note("Testing with $shell");
+    $self->current_shell($shell);
+    is($self->current_shell_is_bashish(), 0, 'current_shell_is_bashish() returns false');
+}
+

--- a/t/splitpath.t
+++ b/t/splitpath.t
@@ -1,0 +1,11 @@
+use warnings;
+use strict;
+use Test::More tests => 3;
+use Test::Exception;
+use App::perlbrew;
+
+my @long_path = qw(this is a long path to check if it is joined ok);
+unshift(@long_path, '');
+is(App::perlbrew::splitpath('/this/is/a/long/path/to/check/if/it/is/joined/ok'), @long_path, 'we got the expected path');
+dies_ok { App::perlbrew::splitpath(undef) } 'dies if a undefined parameter is received';
+like($@, qr/^Cannot receive an undefined path as parameter/, 'dies with expected message');


### PR DESCRIPTION
Added parameter validation to `splitpath`.
Added corresponding unit tests for `splitpath`.
Added tests for `current_shell` and `current_shell_is_bashish`. Tests are failing for Korn and C shell, but I guess those are not Bash-ish enough to pass... maybe I caught a bug? 
