### PR TITLE
Fixed expected behavior on bash-ish shell

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -424,7 +424,11 @@ sub current_lib {
 
 sub current_shell_is_bashish {
     my ( $self ) = @_;
-    return $self->current_shell =~ /(ba|z)?sh/;
+    if (($self->current_shell eq 'bash') or ($self->current_shell eq 'zsh')) {
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 sub current_shell {


### PR DESCRIPTION
current_shell_is_bashish now returns true only for "bash" or "zsh".
It should, at least, fix the "broken" test right now.