### PR TITLE
Clone module help

### DIFF
--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -620,7 +620,15 @@ which are not necessarily the I<same> module versions you had installed previous
 
 =head1 COMMAND: CLONE-MODULES
 
-This command re-install all CPAN modules found from one installation to another.
+This command re-installs all CPAN modules found from one installation to another.
+
+Usage:
+    perlbrew clone-modules <src_version> <dst_version>
+
+for example
+
+    perlbrew clone-modules 5.26.1 5.27.7
+
 
 =head1 SEE ALSO
 

--- a/bin/perlbrew
+++ b/bin/perlbrew
@@ -35,6 +35,7 @@ Commands:
     switch         Permanently use the specified perl as default
     switch-off     Permanently turn off perlbrew (revert to system perl)
     exec           exec programs with specified perl environments.
+    clone-modules  re-installs all CPAN modules from one installation to another
 
     self-install       Install perlbrew itself under PERLBREW_ROOT/bin
     self-upgrade       Upgrade perlbrew itself.
@@ -613,7 +614,7 @@ your module installation to different perl. The following command
 re-installs all modules under perl-5.16.0:
 
     perlbrew list-modules | perlbrew exec --with perl-5.16.0 cpanm
-    
+
 Note that this installs the I<latest> versions of the Perl modules on the new perl,
 which are not necessarily the I<same> module versions you had installed previously.
 

--- a/perlbrew
+++ b/perlbrew
@@ -6453,6 +6453,7 @@ Commands:
     switch         Permanently use the specified perl as default
     switch-off     Permanently turn off perlbrew (revert to system perl)
     exec           exec programs with specified perl environments.
+    clone-modules  re-installs all CPAN modules from one installation to another
 
     self-install       Install perlbrew itself under PERLBREW_ROOT/bin
     self-upgrade       Upgrade perlbrew itself.


### PR DESCRIPTION
For some reason the clone-modules command is not visible within the online help, while it is via the help command.
I've added it to the list of quick help commands, and improved the help section with an example.