### PR TITLE
Fix tests for perl 5.8

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2418,10 +2418,11 @@ sub run_command_exec {
         my %env = $self->perlbrew_env($i->{name});
         next if !$env{PERLBREW_PERL};
 
-        local @ENV{ keys %env } = values %env;
-        local $ENV{PATH}    = join(':', $env{PERLBREW_PATH}, $ENV{PATH});
-        local $ENV{MANPATH} = join(':', $env{PERLBREW_MANPATH}, $ENV{MANPATH}||"");
-        local $ENV{PERL5LIB} = $env{PERL5LIB} || "";
+        local %ENV = %ENV;
+        $ENV{$_} = defined $env{$_} ? $env{$_} : '' for keys %env;
+        $ENV{PATH}    = join(':', $env{PERLBREW_PATH}, $ENV{PATH});
+        $ENV{MANPATH} = join(':', $env{PERLBREW_MANPATH}, $ENV{MANPATH}||"");
+        $ENV{PERL5LIB} = $env{PERL5LIB} || "";
 
         print "$i->{name}\n==========\n" unless $no_header || $self->{quiet};
 


### PR DESCRIPTION
Because `$ENV{FOO} = undef` emits warnings undef perl 5.8, t/command-exec.t fails under perl 5.8.
This PR fixes that.

cf: https://github.com/Test-More/Test2-Harness/issues/25

### before

```
❯ perl -v
This is perl, v5.8.8 built for darwin-2level

❯ git log -1
commit 62e3c5b49fb77a5524e55d7c34df38f6dcddfed4 (HEAD -> develop, origin/develop, origin/HEAD)
Author: Kang-min Liu <gugod@gugod.org>
Date:   Fri Feb 23 16:27:00 2018 +0900

❯ prove -l t/command-exec.t
t/command-exec.t .. Use of uninitialized value in list assignment at /Users/skaji/src/github.com/gugod/App-perlbrew/lib/App/perlbrew.pm line 2421.
...
Test Summary Report
-------------------
t/command-exec.t (Wstat: 512 Tests: 37 Failed: 2)
  Failed tests:  19-20
  Non-zero exit status: 2
Files=1, Tests=37,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.19 cusr  0.06 csys =  0.28 CPU)
Result: FAIL
```

### after
```
❯ perl -v
This is perl, v5.8.8 built for darwin-2level

❯ git log -1
commit 0a68984cdfcba5b6305027702bf7e9751cee6181 (HEAD -> fix-test-for-5.8)
Author: Shoichi Kaji <skaji@cpan.org>
Date:   Sun Feb 25 01:25:15 2018 +0900

❯ prove -l t/command-exec.t
t/command-exec.t .. 1/? Command [perl -E 'somesub 42'] terminated with exit code 7 ($? = 1792) under the following perl environment:
format_info_output_value
Command [perl -E 'say 42'] terminated with exit code 3 ($? = 768) under the following perl environment:
Command [perl -E 'say 42'] terminated with exit code 3 ($? = 768) under the following perl environment:
Command [perl -E 'say 42'] terminated with exit code 3 ($? = 768) under the following perl environment:
Command [perl -E 'say 42'] terminated with exit code 255 ($? = -1) under the following perl environment:
Command [perl -E 'say 42'] terminated with exit code 7 ($? = 1792) under the following perl environment:
t/command-exec.t .. ok
All tests successful.
Files=1, Tests=37,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.20 cusr  0.05 csys =  0.27 CPU)
Result: PASS
```