### PR TITLE
New implementation of the comparable_perl_version function.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -760,6 +760,7 @@ sub _compgen {
 # multiplied by a negative factor (-1) in order
 # to make cperl being "less" in the ordered list
 # than a normal Perl installation.
+<<<<<<< HEAD
 sub comparable_perl_version {
     my ( $self, $perl_version ) = @_;
     if ( $perl_version =~ /^(?:(c?perl)-?)?(\d)\.(\d+).(\d+).*/ ){
@@ -771,6 +772,41 @@ sub comparable_perl_version {
                        $4 );                                   # patch level
     }
     return 0;
+=======
+#
+# The returned string is made by four pieces of two digits each:
+# MMmmppbb
+# where:
+# MM is the major Perl version (e.g., 5 -> 05)
+# mm is the minor Perl version (e.g. 27 -> 27)
+# pp is the patch level (e.g., 4 -> 04)
+# bb is the blead flag: it is 00 for a "normal" release, or 01 for a blead one
+sub comparable_perl_version {
+    my ( $self, $perl_version )   = @_;
+    my ( $is_cperl, $is_blead )   = ( 0, 0 );
+    my ( $major, $minor, $patch ) = ( 0, 0, 0 );
+    if ( $perl_version =~ /^(?:(c?perl)-?)?(\d)\.(\d+).(\d+).*/ ){
+        $is_cperl = $1 && ($1 eq 'cperl');
+        $major    = $2 + ( $is_cperl ? 6 : 0 );             # major version
+        $minor    = $3;                                     # minor version
+        $patch    = $4;                                     # patch level
+
+    }
+    elsif ( $perl_version =~ /^(?:(c?perl)-?)?-?(blead)$/ ) {
+        # in the case of a blead release use a fake high number
+        # to assume it is the "latest" release number available
+        $is_cperl = $1 && ($1 eq 'cperl');
+        $is_blead = $2 && ($2 eq 'blead' );
+        ( $major, $minor, $patch ) = ( 5, 99, 99 );
+    }
+
+    return ( $is_cperl ? -1 : 1 )
+        * sprintf( '%02d%02d%02d%02d',
+                   $major + ( $is_cperl ? 6 : 0 ),             # major version
+                   $minor,                                     # minor version
+                   $patch,                                     # patch level
+                   $is_blead );                                # blead
+>>>>>>> 73d8f17... New implementation of the comparable_perl_version function.
 }
 
 # Internal method.

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -760,19 +760,6 @@ sub _compgen {
 # multiplied by a negative factor (-1) in order
 # to make cperl being "less" in the ordered list
 # than a normal Perl installation.
-<<<<<<< HEAD
-sub comparable_perl_version {
-    my ( $self, $perl_version ) = @_;
-    if ( $perl_version =~ /^(?:(c?perl)-?)?(\d)\.(\d+).(\d+).*/ ){
-        my $is_cperl = $1 && ($1 eq 'cperl');
-        return ( $is_cperl ? -1 : 1 )
-            * sprintf( '%02d%03d%03d',
-                       $2 + ( $is_cperl ? 6 : 0 ),             # major version
-                       $3,                                     # minor version
-                       $4 );                                   # patch level
-    }
-    return 0;
-=======
 #
 # The returned string is made by four pieces of two digits each:
 # MMmmppbb
@@ -806,7 +793,6 @@ sub comparable_perl_version {
                    $minor,                                     # minor version
                    $patch,                                     # patch level
                    $is_blead );                                # blead
->>>>>>> 73d8f17... New implementation of the comparable_perl_version function.
 }
 
 # Internal method.


### PR DESCRIPTION
Now there are two branches to select a version: a numeric one and a blead one.
The former works pretty much as in the past, converting a version number
to a string made by MMmmpp00 (MM = Major, mm = minor, pp = patch).
The "blead" branch converts it to 99999901 to indicate a major version number.
Since there could be only one blead, it should be ok to keep the number
fixed.

It is important to note that the format of comparable_perl_version is chaned, being now made by four blocks of two digits each.

See issue #606 