### PR TITLE
use metacpan to find perl releases instead of cpansearch

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,7 @@ requires
     'Pod::Parser'          => '1.63',
     'Pod::Usage'           => '1.68',
     'File::Temp'           => '0.2304',
+    'JSON::PP'             => '0',
     'local::lib'           => '2.000014';
 
 test_requires

--- a/dev-bin/update-fatlib.pl
+++ b/dev-bin/update-fatlib.pl
@@ -11,6 +11,7 @@ my $modules = [ split /\s+/, <<MODULES ];
 local/lib.pm
 Capture/Tiny.pm
 CPAN/Perl/Releases.pm
+JSON/PP.pm
 MODULES
 
 my $packer = App::FatPacker->new;

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -22,6 +22,7 @@ BEGIN {
 use File::Glob 'bsd_glob';
 use Getopt::Long ();
 use CPAN::Perl::Releases;
+use JSON::PP 'decode_json';
 
 sub min(@) {
     my $m = $_[0];
@@ -930,17 +931,18 @@ sub perl_release {
         }
     }
 
-    my $html = http_get("http://search.cpan.org/dist/perl-${version}", { 'Cookie' => "cpan=$mirror" });
+    my $json = http_get("https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-${version}");
 
-    unless ($html) {
+    my $result;
+    unless ($json and $result = decode_json($json)->{hits}{hits}[0]) {
         die "ERROR: Failed to locate perl-${version} tarball.";
     }
 
     my ($dist_path, $dist_tarball) =
-        $html =~ m[<a href="(/CPAN/authors/id/.+/(perl-${version}.tar.(gz|bz2)))">Download</a>];
+        $result->{_source}{download_url} =~ m[(/authors/id/.+/(perl-${version}.tar.(gz|bz2|xz)))$];
     die "ERROR: Cannot find the tarball for perl-$version\n"
         if !$dist_path and !$dist_tarball;
-    my $dist_tarball_url = "http://search.cpan.org${dist_path}";
+    my $dist_tarball_url = "https://cpan.metacpan.org${dist_path}";
     return ($dist_tarball, $dist_tarball_url);
 }
 
@@ -1005,17 +1007,18 @@ sub release_detail_perl_remote {
         }
     }
 
-    my $html = http_get("http://search.cpan.org/dist/perl-${version}", { 'Cookie' => "cpan=$mirror" });
+    my $json = http_get("https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-${version}");
 
-    unless ($html) {
+    my $result;
+    unless ($json and $result = decode_json($json)->{hits}{hits}[0]) {
         die "ERROR: Failed to locate perl-${version} tarball.";
     }
 
     my ($dist_path, $dist_tarball) =
-        $html =~ m[<a href="(/CPAN/authors/id/.+/(perl-${version}.tar.(gz|bz2)))">Download</a>];
+        $result->{_source}{download_url} =~ m[(/authors/id/.+/(perl-${version}.tar.(gz|bz2|xz)))$];
     die "ERROR: Cannot find the tarball for perl-$version\n"
         if !$dist_path and !$dist_tarball;
-    my $dist_tarball_url = "http://search.cpan.org${dist_path}";
+    my $dist_tarball_url = "https://cpan.metacpan.org${dist_path}";
 
     $rd->{tarball_name} = $dist_tarball;
     $rd->{tarball_url} = $dist_tarball_url;


### PR DESCRIPTION
See https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html

Related: https://github.com/tokuhirom/Perl-Build/pull/67