### PR TITLE
Use metacpan

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -874,7 +874,7 @@ sub available_perls_with_urls {
         # if we have a $current_perl add it to the available hash of perls
         if ( $current_perl ){
             $current_perl =~ s/\.tar\.gz//;
-            push @perllist, [ $current_perl, 'FROMCPAN' ];
+            push @perllist, [ $current_perl, $current_url ];
             $perls->{ $current_perl } = $current_url;
         }
     }
@@ -899,7 +899,11 @@ sub available_perls_with_urls {
         push @perllist, [ $current_perl, $current_url ];
     }
     foreach my $perl ( $self->filter_perl_available(\@perllist) ) {
-        $perls->{ $perl->[0] } = $perl->[1];
+        # We only want to add a Metacpan link if the www.cpan.org link
+        # doesn't exist, and this assures that we do that properly.
+        if (!exists($perls->{ $perl->[0] })) {
+            $perls->{ $perl->[0] } = $perl->[1];
+        }
     }
     
 
@@ -925,22 +929,20 @@ sub available_perls_with_urls {
 # $perllist is an arrayref of arrayrefs.  The inner arrayrefs are of the
 # format: [ <perl_name>, <perl_url> ]
 #   perl_name = something like perl-5.28.0
-#   perl_url  = URL the Perl is available from.  If the URL is
-#     "FROMCPAN", it is just used to make sure we don't include an older
-#     version from CPAN - but it won't ever appear in the output.
+#   perl_url  = URL the Perl is available from.
 #
 # If $self->{all} is true, this just returns a list of the contents of
-# the list referenced by $perllist, except where URL eq FROMCPAN.
+# the list referenced by $perllist
 #
 # Otherwise, this looks for even middle numbers in the version and no
 # suffix (like -RC1) following the URL, and returns the list of
-# arrayrefs that so match and don't have a URL of FROMCPAN.
+# arrayrefs that so match
 #
 # If any "newest" Perl has a 
 sub filter_perl_available {
     my ($self, $perllist) = @_;
 
-    if ($self->{all}) { return grep { $_ ne 'FROMCPAN' } @$perllist; }
+    if ($self->{all}) { return @$perllist; }
 
     my %max_release;
     foreach my $perl (@$perllist) {
@@ -955,7 +957,7 @@ sub filter_perl_available {
         $max_release{$release_line} = [ $minor, $perl ];
     }
 
-    return grep { $_->[1] ne 'FROMCPAN' } map { $_->[1] } values %max_release;
+    return map { $_->[1] } values %max_release;
 }
 
 sub perl_release {

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -854,6 +854,7 @@ sub available_perls {
 sub available_perls_with_urls {
     my ( $self, $dist, $opts ) = @_;
     my $perls = {};
+    my @perllist;
 
     my $url = $self->{all}  ? "https://www.cpan.org/src/5.0/"
                             : "https://www.cpan.org/src/README.html" ;
@@ -873,9 +874,34 @@ sub available_perls_with_urls {
         # if we have a $current_perl add it to the available hash of perls
         if ( $current_perl ){
             $current_perl =~ s/\.tar\.gz//;
+            push @perllist, [ $current_perl, 'FROMCPAN' ];
             $perls->{ $current_perl } = $current_url;
         }
     }
+
+
+    # we got impatient waiting for cpan.org to get updated to show 5.28...
+    # So, we also fetch from metacpan for anything that looks perlish,
+    # and we do our own processing to filter out the development
+    # releases and minor versions when needed (using
+    # filter_perl_available)
+    $url = 'https://fastapi.metacpan.org/v1/release/_search'
+        . '\?q=distribution:perl%20AND%20archive:perl-5.%2A.%2A.tar.gz%20AND%20NOT%20status:backpan'
+        . '\&fields=download_url\&size=100';
+    $html = http_get( $url, undef, undef );
+    unless($html) {
+        $html = '';
+        warn "\nERROR: Unable to retrieve list of perls from Metacpan.\n\n";
+    }
+    while ( $html =~ m|"(http(?:s?)://cpan\.metacpan\.org/[^"]+/(perl-5\.[0-9]+\.[0-9]+(?:-[A-Z0-9]+)?)\.tar\.gz)"|g ) {
+        my ( $current_perl, $current_url ) = ( $2, $1 );;
+
+        push @perllist, [ $current_perl, $current_url ];
+    }
+    foreach my $perl ( $self->filter_perl_available(\@perllist) ) {
+        $perls->{ $perl->[0] } = $perl->[1];
+    }
+    
 
     # cperl releases: https://github.com/perl11/cperl/tags
     my $cperl_remote        = 'https://github.com';
@@ -894,6 +920,42 @@ sub available_perls_with_urls {
 
 
     return $perls;
+}
+
+# $perllist is an arrayref of arrayrefs.  The inner arrayrefs are of the
+# format: [ <perl_name>, <perl_url> ]
+#   perl_name = something like perl-5.28.0
+#   perl_url  = URL the Perl is available from.  If the URL is
+#     "FROMCPAN", it is just used to make sure we don't include an older
+#     version from CPAN - but it won't ever appear in the output.
+#
+# If $self->{all} is true, this just returns a list of the contents of
+# the list referenced by $perllist, except where URL eq FROMCPAN.
+#
+# Otherwise, this looks for even middle numbers in the version and no
+# suffix (like -RC1) following the URL, and returns the list of
+# arrayrefs that so match and don't have a URL of FROMCPAN.
+#
+# If any "newest" Perl has a 
+sub filter_perl_available {
+    my ($self, $perllist) = @_;
+
+    if ($self->{all}) { return grep { $_ ne 'FROMCPAN' } @$perllist; }
+
+    my %max_release;
+    foreach my $perl (@$perllist) {
+        my $ver = $perl->[0];
+        if ($ver !~ m/^perl-5\.[0-9]*[02468]\.[0-9]+$/) { next; } # most likely TRIAL or RC, or a DEV release
+
+        my ($release_line, $minor) = $ver =~ m/^perl-5\.([0-9]+)\.([0-9]+)/;
+        if (exists $max_release{$release_line}) {
+            if ($max_release{$release_line}->[0] > $minor) { next; } # We have a newer release
+        }
+
+        $max_release{$release_line} = [ $minor, $perl ];
+    }
+
+    return grep { $_->[1] ne 'FROMCPAN' } map { $_->[1] } values %max_release;
 }
 
 sub perl_release {

--- a/t/03.test_get_available_versions.t
+++ b/t/03.test_get_available_versions.t
@@ -7,23 +7,30 @@ use App::perlbrew;
 {
     no warnings 'redefine';
 
-    my $html;
+    my $html_cpan     = read_cpan_html();
+    my $html_metacpan = read_metacpan_html();
 
     sub App::perlbrew::http_get {
-        return $html if $html;
+        my $url = shift;
 
-        local $/ = undef;
-        $html = <DATA>;
+        if ($url =~ m/www\.cpan\.org/) {
+            return $html_cpan;
+        } elsif ($url =~ m/fastapi\.metacpan\.org/) {
+            return $html_metacpan;
+        } else {
+            return '';
+        }
     }
 }
 
-plan tests => 9;
+plan tests => 13;
 
 my $app = App::perlbrew->new();
 my @vers = $app->available_perls();
-is scalar( @vers ), 8, "Correct number of releases found";
+is scalar( @vers ), 12, "Correct number of releases found";
 
 my @known_perl_versions = (
+    'perl-5.28.0',  'perl-5.26.2',  'perl-5.24.4',  'perl-5.22.3',
     'perl-5.13.11', 'perl-5.12.3',  'perl-5.10.1',  'perl-5.8.9',
     'perl-5.6.2',   'perl5.005_04', 'perl5.004_05', 'perl5.003_07'
 );
@@ -32,7 +39,8 @@ for my $perl_version ( $app->available_perls() ) {
     ok grep( $_ eq $perl_version, @known_perl_versions ), "$perl_version found";
 }
 
-__DATA__
+sub read_cpan_html {
+    return <<'EOF';
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -483,3 +491,394 @@ __DATA__
 
 </body>
 </html>
+EOF
+}
+
+sub read_metacpan_html {
+    return <<'EOF';
+{
+   "hits" : {
+      "total" : 41,
+      "max_score" : 3.36797,
+      "hits" : [
+         {
+            "_score" : 3.36797,
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_id" : "cwysy_LCh_cU4sYkQq_XhqwRzVM",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.9.5.tar.gz"
+            }
+         },
+         {
+            "_id" : "6bF8joctVyZMfTxAK6oBCKXxrN0",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.9.3.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SR/SREZIC/perl-5.005-Tk-800.023-bin-0-arm-linux.tar.gz"
+            },
+            "_id" : "j6U8yM_m0OKRWGLvUfc_9nGKjoQ",
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.36797
+         },
+         {
+            "_id" : "g1FYWtQPcw6yrR5dXP2fYH6I1zo",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/G/GS/GSAR/perl-5.6.1.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/G/GS/GSAR/perl-5.6.1-TRIAL3.tar.gz"
+            },
+            "_id" : "SIqDQs0lJGmbEPj_05cIPlPfR_A"
+         },
+         {
+            "_id" : "JuBrDjYXwrh_k_5_FMkZjseSuOw",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/G/GS/GSAR/perl-5.6.1-TRIAL2.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_id" : "ElW8WK1SAx3LISaIm_GZ6WWly1M",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL/perl-5.27.8.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_type" : "release",
+            "_index" : "cpan_v1_01"
+         },
+         {
+            "_id" : "bDbuaoHU6C4UjauBqFqovDALEJY",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4-RC1.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.3.tar.gz"
+            },
+            "_id" : "MLhHV7zvJ2zZ5e_I3MKfsk_iM6A"
+         },
+         {
+            "_id" : "fag73WWtL5Q1HZlFk_yryqfqnrE",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.27.5.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.1.tar.gz"
+            },
+            "_id" : "36dFZmJHuKH4pMdUH0khXuWS2LE"
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.2.tar.gz"
+            },
+            "_id" : "1rwJbxpit3uIv6lk5WcUe4zxxSA"
+         },
+         {
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.27.11.tar.gz"
+            },
+            "_id" : "riJj4D3ZWS49kglzdtz8h19xp7Y"
+         },
+         {
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/J/JH/JHI/perl-5.7.3.tar.gz"
+            },
+            "_id" : "Qb4oEns73TILHWaO9S3kY86yb4A"
+         },
+         {
+            "_score" : 3.36797,
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_id" : "IxX27a_qsQxaRHI883PqEOMNs9A",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.2-RC1.tar.gz"
+            }
+         },
+         {
+            "_id" : "MpJJPG9eHPVjo5LHWPyl7uIn2sU",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0-RC1.tar.gz"
+            },
+            "_score" : 3.36797,
+            "_type" : "release",
+            "_index" : "cpan_v1_01"
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0-RC2.tar.gz"
+            },
+            "_id" : "ykCB3f8FK_sNN4FuXiMsixTc4r0",
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.36797
+         },
+         {
+            "_score" : 3.36797,
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_id" : "SPMWYdPjP_a76kz9tjMfhGNBgaA",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.2.tar.gz"
+            }
+         },
+         {
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.36797,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0.tar.gz"
+            },
+            "_id" : "6YbmfIXsv0IghoL8RsswA6Bcl8M"
+         },
+         {
+            "_id" : "H6QF57CTY4HWj4rx_Urxy2Kk5pA",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/G/GS/GSAR/perl-5.6.1-TRIAL1.tar.gz"
+            },
+            "_score" : 3.2532742,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.2532742,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/G/GS/GSAR/perl-5.6.0.tar.gz"
+            },
+            "_id" : "7MIXoXAMLZWlXfwWTs7L3w26rqk"
+         },
+         {
+            "_id" : "wXO4aI747e_DU6R7DNe3J8s7wsw",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/J/JH/JHI/perl-5.7.0.tar.gz"
+            },
+            "_score" : 3.2532742,
+            "_type" : "release",
+            "_index" : "cpan_v1_01"
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/J/JH/JHI/perl-5.8.0.tar.gz"
+            },
+            "_id" : "nNi1Knyqy7wSnH_mKvSfhl_deGo",
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.2532742
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.2532742,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.10.0.tar.gz"
+            },
+            "_id" : "wfc7JJwuCTJvmW9C4J4tZIActHM"
+         },
+         {
+            "_id" : "GhF4X5JX3OhldWnA_I1t_r4NipE",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.9.1.tar.gz"
+            },
+            "_score" : 3.2532742,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_score" : 3.2532742,
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_id" : "9X4t_9wlwZJMS5d5jIUEdnL1SCA",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.6.2.tar.gz"
+            }
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.2532742,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.27.6.tar.gz"
+            },
+            "_id" : "TwgEl_BI7dKp3BQvZkKqQia5qcU"
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL/perl-5.25.9.tar.gz"
+            },
+            "_id" : "VQfl2bwzqY1bl4tfZmxFaFRY5y8",
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.2532742
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.2532742,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.4-RC1.tar.gz"
+            },
+            "_id" : "ElYIbWVnjcBLopeXvYgo7HSk5Ic"
+         },
+         {
+            "_id" : "DitFBkE2r0aGkPcjH36PbRagPcs",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0-RC3.tar.gz"
+            },
+            "_score" : 3.2532742,
+            "_index" : "cpan_v1_01",
+            "_type" : "release"
+         },
+         {
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.2532742,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0-RC4.tar.gz"
+            },
+            "_id" : "zn33iw3HnI2_5phH9rAhFNmoUps"
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RE/RENEEB/perl-5.27.9.tar.gz"
+            },
+            "_id" : "AuenBK2ImZIVxVzxN0zgVjsunSs",
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.1751823
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/T/TO/TODDR/perl-5.27.10.tar.gz"
+            },
+            "_id" : "_SySZ7HuT9fCjnvKlyUlAAyA7WY",
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.1751823
+         },
+         {
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.4.tar.gz"
+            },
+            "_id" : "k4tD0K2qrojzSwtfXA5A_oxu074",
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_score" : 3.1751823
+         },
+         {
+            "_id" : "QfS1_HGycjW44MsCl73JLC8Is_s",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/J/JH/JHI/perl-5.8.1.tar.gz"
+            },
+            "_score" : 3.1751823,
+            "_type" : "release",
+            "_index" : "cpan_v1_01"
+         },
+         {
+            "_score" : 3.1751823,
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_id" : "CGvg1FBsux5HoXiu7leipfdMTEc",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/J/JH/JHI/perl-5.7.2.tar.gz"
+            }
+         },
+         {
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.1751823,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.9.2.tar.gz"
+            },
+            "_id" : "yvVmPixkFaUceARSy1aKqRPPDBs"
+         },
+         {
+            "_score" : 3.1751823,
+            "_index" : "cpan_v1_01",
+            "_type" : "release",
+            "_id" : "47VQmSAIhurcr84X44RXyKqUMdw",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/perl-5.9.4.tar.gz"
+            }
+         },
+         {
+            "_score" : 3.1751823,
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_id" : "hTJckZ5tEZko8OdmnS8QbWKs10w",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/perl-5.27.7.tar.gz"
+            }
+         },
+         {
+            "_type" : "release",
+            "_index" : "cpan_v1_01",
+            "_score" : 3.1751823,
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/R/RE/RENEEB/perl-5.25.10.tar.gz"
+            },
+            "_id" : "WAMqkmWfSSlBLcSwGZb5DlDD25U"
+         },
+         {
+            "_id" : "bMUgwm4eIPz1ljDFi6aBBFMf6dA",
+            "fields" : {
+               "download_url" : "https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.3.tar.gz"
+            },
+            "_score" : 3.1751823,
+            "_type" : "release",
+            "_index" : "cpan_v1_01"
+         }
+      ]
+   },
+   "_shards" : {
+      "failed" : 0,
+      "total" : 3,
+      "successful" : 3
+   },
+   "took" : 9,
+   "timed_out" : false
+}
+EOF
+}


### PR DESCRIPTION
Currently, the scripts on www.cpan.org do not handle the case where XSAWYERX releases perl - when XSAWYERX does a release, it won't show up on the main Perl 5 source pages.  The same thing happens with the dev releases.

I've also added tests for this new functionality.

This changeset allows Perlbrew to use both www.cpan.org and www.metacpan.org for getting perl.  If you have stylistic or other concerns with this PR, let me know and I'll make whatever changes you feel are appropriate.