### PR TITLE
Get rid of extra whitespace around Perl version

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -865,10 +865,10 @@ sub available_perls_with_urls {
     for ( split "\n", $html ) {
         my ( $current_perl, $current_url );
         if ( $self->{all} ) {
-            ( $current_perl, $current_url ) = ( $2, $1 ) if m|<a href="(perl.*?\.tar\.gz)">(.+?)</a>|;
+            ( $current_perl, $current_url ) = ( $2, $1 ) if m|<a href="(perl.*?\.tar\.gz)">\s*([^\s]+?)\s*</a>|;
         }
         else {
-            ( $current_perl, $current_url ) = ( $2, $1 ) if m|<td><a href="(http(?:s?)://www.cpan.org/src/.+?)">(.+?)</a></td>|;
+            ( $current_perl, $current_url ) = ( $2, $1 ) if m|<td><a href="(http(?:s?)://www.cpan.org/src/.+?)">\s*([^\s]+?)\s*</a></td>|;
         }
 
         # if we have a $current_perl add it to the available hash of perls


### PR DESCRIPTION
This fixes the issue where 5.9.5 showed up twice - careful inspection showed that one had a leading space.  I suspect this broke when the URLs were changed from HTTP to HTTPS on the www.cpan.org box.  This patch strips that whitespace out of the regexes.

This was mentioned in a comment - #622