### PR TITLE
Fix 637

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2838,6 +2838,12 @@ sub run_command_clone_modules {
         $src_perl = pop;
     }
 
+    # does the user specified the same versions?
+    unless ( $src_perl ne $dst_perl ){
+        print "Cannot clone modules on the very same version!\n";
+        exit( -1 );
+    }
+
     # check source and destination do exist
     undef $src_perl if (! $self->resolve_installation_name($src_perl));
     undef $dst_perl if (! $self->resolve_installation_name($dst_perl));

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2776,38 +2776,6 @@ sub run_command_upgrade_perl {
     $self->do_install_release($dist, $dist_version);
 }
 
-# Executes the list-modules command.
-# This routine launches a new perl instance that, thru
-# ExtUtils::Installed prints out all the modules
-# in the system. If an argument is passed to the
-# subroutine it is managed as a filename
-# to which prints the list of modules.
-sub run_command_list_modules {
-    my ($self, $output_filename) = @_;
-    my $class = ref($self) || __PACKAGE__;
-
-    # avoid something that does not seem as a filename to print
-    # output to...
-    undef $output_filename if (! scalar($output_filename));
-
-    my $name = $self->current_env;
-    if (-l (my $path = $self->root->perls ($name))) {
-        $name = $path->readlink->basename;
-    }
-
-    my $app = $class->new(
-        qw(--quiet exec --with),
-        $name,
-        'perl',
-        '-MExtUtils::Installed',
-        '-le',
-        sprintf('BEGIN{@INC=grep {$_ ne q!.!} @INC}; %s print {%s} $_ for ExtUtils::Installed->new->modules;',
-                $output_filename ? sprintf('open my $output_fh, \'>\', "%s"; ', $output_filename) : '',
-                $output_filename ? '$output_fh' : 'STDOUT')
-        );
-
-    $app->run;
-}
 
 sub resolve_installation_name {
     my ($self, $name) = @_;
@@ -2866,16 +2834,28 @@ sub run_command_clone_modules {
         exit(-1);
     }
 
-    # I need to run the list-modules command on myself
+    # I need to run an application to do the module listing.
     # and get the result back so to handle it and pass
     # to the exec subroutine. The solution I found so far
     # is to store the result in a temp file (the list_modules
     # uses a sub-perl process, so there is no way to pass a
     # filehandle or something similar).
-
+    my $class = ref($self);
     require File::Temp;
     my $modules_fh = File::Temp->new;
-    $self->run_command_list_modules($modules_fh->filename);
+
+    # list all the modules and place them in the output file
+    my $src_app = $class->new(
+        qw(--quiet exec --with),
+        $src_perl,
+        'perl',
+        '-MExtUtils::Installed',
+        '-le',
+        sprintf('BEGIN{@INC=grep {$_ ne q!.!} @INC}; open my $output_fh, ">", "%s"; print {$output_fh} $_ for ExtUtils::Installed->new->modules;',
+                $modules_fh->filename )
+        );
+
+    $src_app->run;
 
     # here I should have the list of modules into the
     # temporary file name, so I can ask the destination
@@ -2889,7 +2869,7 @@ sub run_command_clone_modules {
 
     # create a new application to 'exec' the 'cpanm'
     # with the specified module list
-    my $class = ref($self);
+
     my $app = $class->new(
         qw(--quiet exec --with),
         $dst_perl,

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2824,32 +2824,25 @@ sub resolve_installation_name {
 sub run_command_clone_modules {
     my $self = shift;
 
-    my $dst_perl = $self->current_perl;
-    my $src_perl = $self->current_perl;
+    # default to use the currently installation
+    my ( $dst_perl, $src_perl );
 
-    if ( @_ == 1 ){
-        # only one argument, consider it as a destination
-        $dst_perl = shift;
-        print "Using current $src_perl as source for cloning modules into $dst_perl";
-    }
-    else {
-        # at least two arguments, use src as first one
-        $dst_perl = pop;
-        $src_perl = pop;
-    }
+    # the first argument is the destination, the second
+    # optional argument is the source version, default
+    # to use the current installation
+    $dst_perl = pop || $self->current_perl;
+    $src_perl = pop || $self->current_perl;
 
-    # does the user specified the same versions?
-    unless ( $src_perl ne $dst_perl ){
-        print "Cannot clone modules on the very same version!\n";
-        exit( -1 );
-    }
 
     # check source and destination do exist
     undef $src_perl if (! $self->resolve_installation_name($src_perl));
     undef $dst_perl if (! $self->resolve_installation_name($dst_perl));
 
-    if ( ! $src_perl || ! $dst_perl ){
-        # cannot understand from where to where...
+    if ( ! $src_perl
+         || ! $dst_perl
+         || $src_perl eq $dst_perl ){
+        # cannot understand from where to where or
+        # the user did specify the same versions
         $self->run_command_help('clone_modules');
         exit(-1);
     }

--- a/perlbrew
+++ b/perlbrew
@@ -43242,11 +43242,14 @@ This command re-installs all CPAN modules found from one installation to another
 
 Usage:
     perlbrew clone-modules <src_version> <dst_version>
+    perlbrew clone-modules <dst_version>
 
 for example
 
     perlbrew clone-modules 5.26.1 5.27.7
 
+If no source version is specified, the currently used instance
+will be used as source.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
A possible fix to some odds of `clone-modules`.

It does fix the problem of not cloning modules from the right instance (it was always using `current_perl` as source).
It makes the first argument optional, using the current instance as the source if only one version has been specified.
It makes some other extra check and removes the no more used `run_command_list_modules` method.

See #637 