### PR TITLE
do not die if neither fetch nor wget are installed but curl is

### DIFF
--- a/t/http-ua-detect-non-curl.t
+++ b/t/http-ua-detect-non-curl.t
@@ -27,7 +27,9 @@ elsif (which("fetch")) {
     $expected_ua = "fetch";
 }
 
-my $detected_ua = App::perlbrew::http_user_agent_program();
-is $detected_ua, $expected_ua, "UA: $detected_ua";
+if ($expected_ua) {
+    my $detected_ua = App::perlbrew::http_user_agent_program();
+    is $detected_ua, $expected_ua, "UA: $detected_ua";
+}
 
 done_testing;


### PR DESCRIPTION
The test died when `curl` is installed but neither `wget` nor `fetch` is available. In that case `App::perlbrew::http_user_agent_program()` died with an exception.