### PR TITLE
Jkjacobson list align

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2133,7 +2133,7 @@ sub run_command_list {
     my $is_verbose = $self->{verbose};
 
     for my $i ($self->installed_perls) {
-        printf "%2s %-20s %-20s %s\n",
+        printf "%-2s%-20s %-20s %s\n",
             $i->{is_current} ? '*' : '',
             $i->{name},
             ( $is_verbose ?

--- a/t/command-list.t
+++ b/t/command-list.t
@@ -32,7 +32,7 @@ describe "list command," => sub {
     describe "when there no libs under PERLBREW_HOME,", sub {
         it "displays a list of perl installation names", sub {
             my $app = App::perlbrew->new("list");
-            stdout_like sub { $app->run(); }, qr/^(\s\*)?\s{1,3}c?perl-?\d\.\d{1,3}[_.]\d{1,2}\s+/, 'Cannot find Perl in output'
+            stdout_like sub { $app->run(); }, qr/^(\s|\*)\sc?perl-?\d\.\d{1,3}[_.]\d{1,2}\s+/, 'Cannot find Perl in output'
         };
     };
 
@@ -48,13 +48,13 @@ describe "list command," => sub {
 
         it "displays lib names" => sub {
             my $app = App::perlbrew->new("list");
-            stdout_like sub { $app->run(); }, qr/^(\s\*)?\s{1,3}c?perl-?\d\.\d{1,3}[_.]\d{1,2}(@\w+)?/, 'Cannot find Perl with libraries in output'
+            stdout_like sub { $app->run(); }, qr/^(\s|\*)\sc?perl-?\d\.\d{1,3}[_.]\d{1,2}(@\w+)?/, 'Cannot find Perl with libraries in output'
         };
 
         it "marks currently activated lib", sub {
             $ENV{PERLBREW_LIB} = "nobita";
             my $app = App::perlbrew->new("list");
-            stdout_like sub { $app->run(); }, qr/^(\s\*)?\s{1,3}c?perl-?\d\.\d{1,3}[_.]\d{1,2}(\@nobita)?/, 'Cannot find Perl with libraries in output'
+            stdout_like sub { $app->run(); }, qr/^(\s|\*)\sc?perl-?\d\.\d{1,3}[_.]\d{1,2}(\@nobita)?/, 'Cannot find Perl with libraries in output'
 
         };
     };


### PR DESCRIPTION
This patch seeks to correct the issue below, where there is an extra character for the installed perls as compared to the installed libs:
```
  * perl-5.16.3
   perl-5.16.3@NAME

    perl-5.16.3
 * perl-5.16.3@NAME
```
I've tightened the regex in an appropriate test -- t/command-list.t -- to verify that that the prefix remains exactly two characters: `'* '` when selected and `'  '` when not selected.