### PR TITLE
URL quoting to fix "ERROR: Cannot find the tarball for perl-$version"

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -948,7 +948,7 @@ sub perl_release {
         }
     }
 
-    my $json = http_get("https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-${version}");
+    my $json = http_get("'https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-${version}'");
 
     my $result;
     unless ($json and $result = decode_json($json)->{hits}{hits}[0]) {
@@ -1024,7 +1024,7 @@ sub release_detail_perl_remote {
         }
     }
 
-    my $json = http_get("https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-${version}");
+    my $json = http_get("'https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-${version}'");
 
     my $result;
     unless ($json and $result = decode_json($json)->{hits}{hits}[0]) {


### PR DESCRIPTION
When trying to install the new perl-5.30.0 release with Perlbrew, I got the error: `ERROR: Cannot find the tarball for perl-5.30.0`.  I tracked down the issue and discovered that the metacpan API URL was being passed to curl to be run directly in the shell.  The shell breaks the URL argument at the `&`, interpreting it as the shell built-in instead of the URL query param syntax, and erroneously returned a result for the query `https://fastapi.metacpan.org/v1/release/_search?size=1` (instead of `https://fastapi.metacpan.org/v1/release/_search?size=1&q=name:perl-5.30.0`), producing a result for a different package altogether, and subsequently making the perl version regex match fail.

The fix was to simply pass in the URL with embedded quotes to `http_get`.