### PR TITLE
remove the core "Perl" module from "list-modules" command

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2777,7 +2777,7 @@ sub run_command_list_modules {
         'perl',
         '-MExtUtils::Installed',
         '-le',
-        sprintf('BEGIN{@INC=grep {$_ ne q!.!} @INC}; %s print {%s} $_ for ExtUtils::Installed->new->modules;',
+        sprintf('BEGIN{@INC=grep {$_ ne q!.!} @INC}; %s print {%s} $_ for grep {$_ ne q!Perl!} ExtUtils::Installed->new->modules;',
                 $output_filename ? sprintf('open my $output_fh, \'>\', "%s"; ', $output_filename) : '',
                 $output_filename ? '$output_fh' : 'STDOUT')
     );


### PR DESCRIPTION
`ExtUtils::Installed->new->modules` returns the special module "Perl" for the core.
See https://metacpan.org/pod/ExtUtils::Installed#modules()

As a result, `perlbrew list-modules` also returns "Perl" module.
I think we should remove it because it is not a real module.