### PR TITLE
Fix calling patchperl on readonly files

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1771,7 +1771,7 @@ INSTALL
         "cd $dist_extracted_dir",
         "rm -f config.sh Policy.sh",
     );
-    push @preconfigure_commands, $patchperl unless $self->{"no-patchperl"} || $looks_like_we_are_installing_cperl;
+    push @preconfigure_commands, 'chmod -R +w .', $patchperl unless $self->{"no-patchperl"} || $looks_like_we_are_installing_cperl;
 
     my $configure_flags = $self->env("PERLBREW_CONFIGURE_FLAGS") || '-de';
 


### PR DESCRIPTION
Older perl tarballs (e.g. 5.005_03) have all files marked as readonly.
Patchperl is not able to patch these files and fails. So prior to calling
patchperl, use chmod for adding write permission for all unpacked files.

This change fixes support for building Perl 5.005_03.