### PR TITLE
"~/zshenv" should be "~/.zshenv"

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1172,11 +1172,11 @@ sub run_command_init {
         elsif ($shell =~ m/zsh\d?$/) {
             $code = "source $root_dir/etc/bashrc";
             $yourshrc = $self->_firstrcfile(qw(
-                zshenv
+                .zshenv
                 .bash_profile
                 .bash_login
                 .profile
-            )) || "zshenv";
+            )) || ".zshenv";
         }
         elsif ($shell =~ m/fish/) {
             $code = ". $root_dir/etc/perlbrew.fish";


### PR DESCRIPTION
In the notes that appear after installing perlbrew from zsh:

```
Append the following piece of code to the end of your ~/zshenv and start a
new shell, perlbrew should be up and fully functional from there:

    source ~/perl5/perlbrew/etc/bashrc
```

I believe `~/zshenv` should instead say `~/.zshenv`, since zsh sources `~/.zshenv` by default, and not `~/zshenv`.

I have not tested this PR, but I hope that it is what addresses this issue.
