### PR TITLE
Show HTTP errors in console when there is an error downloading something

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1302,7 +1302,7 @@ sub do_install_url {
     else {
         print "Fetching $dist as $dist_tarball_path\n";
         my $error = http_download($dist_tarball_url, $dist_tarball_path);
-        die "ERROR: Failed to download $dist_tarball_url\n" if $error;
+        die "ERROR: Failed to download $dist_tarball_url\n$error\n" if $error;
     }
 
     my $dist_extracted_path = $self->do_extract_tarball($dist_tarball_path);
@@ -1572,7 +1572,7 @@ sub run_command_download {
         print "Download $dist_tarball_url to $dist_tarball_path\n" unless $self->{quiet};
         my $error = http_download($dist_tarball_url, $dist_tarball_path);
         if ($error) {
-            die "ERROR: Failed to download $dist_tarball_url\n";
+            die "ERROR: Failed to download $dist_tarball_url\n$error\n";
         }
     }
 }


### PR DESCRIPTION
I'm trying to debug an error that happens in Azure pipelines (https://dev.azure.com/autarch0554/houseabsolute/_build/results?buildId=205&view=logs&j=9196a9a8-28e1-55cc-90c9-e385c43ebc57&t=596ab9e3-66a0-5e2e-9d22-024d38deba14) and I'd really like to see what is actually going wrong here.