### PR TITLE
fix: remove .tar.bz2 suffix in perl version string

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -839,7 +839,7 @@ sub available_perls_with_urls {
 
         # if we have a $current_perl add it to the available hash of perls
         if ($current_perl) {
-            $current_perl =~ s/\.tar\.gz//;
+            $current_perl =~ s/\.tar\.(bz2|gz)//;
             push @perllist, [ $current_perl, $current_url ];
             $perls->{$current_perl} = $current_url;
         }

--- a/t/03.test_get_available_versions.t
+++ b/t/03.test_get_available_versions.t
@@ -149,7 +149,7 @@ sub read_cpan_html {
         <td>5.13.11
         <td>Devel</td>
         <td>2011-03-20</td>
-        <td><a href="https://www.cpan.org/src/perl-5.13.11.tar.gz">perl-5.13.11.tar.gz</a></td>
+        <td><a href="https://www.cpan.org/src/perl-5.13.11.tar.bz2">perl-5.13.11.tar.bz2</a></td>
     </tr>
 
 


### PR DESCRIPTION
The tarballs on the [CPAN Perl Source page](https://www.cpan.org/src/README.html ) used to end with `tar.gz`, but now for some reason most of them are `tar.bz2`, which is not appropriately handled in the code.

#684 

![image](https://user-images.githubusercontent.com/1468378/72878089-43e71480-3d35-11ea-84b2-99ceb77b7287.png)
