### PR TITLE
Make perlbrew bashrc compatible with bash -u

### DIFF
--- a/perlbrew
+++ b/perlbrew
@@ -3225,7 +3225,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
   }
   
   __perlbrew_set_path () {
-      export MANPATH=$PERLBREW_MANPATH${PERLBREW_MANPATH:+:}$(__perlbrew_purify "$(manpath 2>/dev/null)")
+      export MANPATH=${PERLBREW_MANPATH:-}${PERLBREW_MANPATH:+:}$(__perlbrew_purify "$(manpath 2>/dev/null)")
       export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify "$PATH")
       hash -r
   }
@@ -3239,8 +3239,8 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
   __perlbrew_activate() {
       [[ -n $(alias perl 2>/dev/null) ]] && unalias perl 2>/dev/null
   
-      if [[ -n "$PERLBREW_PERL" ]]; then
-          __perlbrew_set_env "$PERLBREW_PERL${PERLBREW_LIB:+@}$PERLBREW_LIB"
+      if [[ -n "${PERLBREW_PERL:-}" ]]; then
+          __perlbrew_set_env "${PERLBREW_PERL:-}${PERLBREW_LIB:+@}$PERLBREW_LIB"
       fi
   
       __perlbrew_set_path
@@ -3306,22 +3306,21 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
       return ${exit_status:-0}
   }
   
-  [[ -z "$PERLBREW_ROOT" ]] && export PERLBREW_ROOT="$HOME/perl5/perlbrew"
-  [[ -z "$PERLBREW_HOME" ]] && export PERLBREW_HOME="$HOME/.perlbrew"
+  [[ -z "${PERLBREW_ROOT:-}" ]] && export PERLBREW_ROOT="$HOME/perl5/perlbrew"
+  [[ -z "${PERLBREW_HOME:-}" ]] && export PERLBREW_HOME="$HOME/.perlbrew"
   
-  if [[ ! -n "$PERLBREW_SKIP_INIT" ]]; then
-      if [[ -f "$PERLBREW_HOME/init" ]]; then
+  if [[ ! -n "${PERLBREW_SKIP_INIT:-}" ]]; then
+      if [[ -f "${PERLBREW_HOME:-}/init" ]]; then
           . "$PERLBREW_HOME/init"
       fi
   fi
   
-  perlbrew_bin_path="${PERLBREW_ROOT}/bin"
-  if [[ -f $perlbrew_bin_path/perlbrew ]]; then
-      perlbrew_command="$perlbrew_bin_path/perlbrew"
+
+  if [[ -f "${PERLBREW_ROOT:-}/bin/perlbrew" ]]; then
+      perlbrew_command="${PERLBREW_ROOT:-}/bin/perlbrew"
   else
       perlbrew_command="perlbrew"
   fi
-  unset perlbrew_bin_path
   
   __perlbrew_activate
   

--- a/perlbrew-install
+++ b/perlbrew-install
@@ -6,11 +6,11 @@ if [ -z "${PERLBREWURL}" ]; then
 fi
 
 clean_exit () {
-    [ ! -z "$LOCALINSTALLER" -a -f "$LOCALINSTALLER" ] && rm $LOCALINSTALLER
+    [ ! -z "${LOCALINSTALLER:-}" -a -f "${LOCALINSTALLER:-}" ] && rm ${LOCALINSTALLER:-}
     exit $1
 }
 
-if [ -z "$TMPDIR" -o ! -d "$TMPDIR" ]; then
+if [ -z "${TMPDIR:-}" -o ! -d "${TMPDIR:-}" ]; then
     if [ -d "/tmp" ]; then
         TMPDIR="/tmp"
     else


### PR DESCRIPTION
## **Problem statement**

1. Sourcing the provided `bashrc` from scripts where `set -u` (error on unset variables) will error.
2. Similarly, the bootstrap script also cannot be run with `curl -L https://install.perlbrew.pl | bash -eu` or similar.

## Solution

In bash scripts where unset variables are possible replace `"$VAR"` or `${VAR}` with `${VAR:-}`
This leverages bash default parameter substitution to explicitly provide a default value -- but because one is not provided it defaults to empty string (null).  In practice `${VAR:-}` is identical to the more explicit `${VAR:-''}` (empty string as default value).

Basically this makes explicit that having these variables unset/empty is safe as far as perlbrew is concerned:
```
PERLBREW_ROOT
PERLBREW_HOME
PERLBREW_PERL
PERLBREW_MANPATH
TMPDIR
```

## Result

This allows users to enable safer bash options (e.g. `set -euf -o pipefail`) in scripts dependent on perlbrew.

## References:

https://tldp.org/LDP/abs/html/parameter-substitution.html
https://sipb.mit.edu/doc/safe-shell/