### PR TITLE
Fix perlbrew.fish syntax error and forgotten change unsetenv to set -eg

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -3118,7 +3118,7 @@ function __perlbrew_set_path
 end
 
 function __perlbrew_set_env
-    set -l code (eval $perlbrew_command env $argv | perl -pe 's/^(export|setenv)/set -xg/; s/=/ /; s/^unset[env]*/set -eug/; s/$/;/; y/:/ /')
+    set -l code (eval $perlbrew_command env $argv | perl -pe 's/^(export|setenv)/set -xg/; s/=/ /; s/^unset[env]*/set -eg/; s/$/;/; y/:/ /')
 
     if test -z "$code"
         return 0;
@@ -3196,7 +3196,7 @@ function perlbrew
 end
 
 function __source_init
-    perl -pe's/^(export|setenv)/set -xg/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | source
+    perl -pe's/unsetenv/set -eg/; s/^(export|setenv)/set -xg/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | source
 end
 
 if test -z "$PERLBREW_ROOT"


### PR DESCRIPTION
Fix #697 