### PR TITLE
Fix build.sh for using shell other than bash as login shell

### DIFF
--- a/dev-bin/build.sh
+++ b/dev-bin/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+SHELL=/bin/bash
 eval "$(perlbrew init-in-bash)"
 # source $HOME/perl5/perlbrew/etc/bashrc
 


### PR DESCRIPTION
Set bash path on the SHELL variable because this script is bash script.
This modification make becoming able to build on shell other than bash.