### PR TITLE
Fix set env script for fish

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -3118,7 +3118,7 @@ function __perlbrew_set_path
 end
 
 function __perlbrew_set_env
-    set -l code (eval $perlbrew_command env $argv | perl -pe 's/^(export|setenv)/set -xg/; s/=/ /; s/^unset[env]*/set -eg/; s/$/;/; y/:/ /')
+    set -l code (eval $perlbrew_command env $argv | perl -pe 's/^(export|setenv)/set -xg/; s/=/ /; s/^unset(env)* (.*)/if test -n "\$$2"; set -eg $2; end/; s/$/;/; y/:/ /')
 
     if test -z "$code"
         return 0;
@@ -3196,7 +3196,7 @@ function perlbrew
 end
 
 function __source_init
-    perl -pe's/unsetenv/set -eg/; s/^(export|setenv)/set -xg/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | source
+    perl -pe 's/^(export|setenv)/set -xg/; s/^unset(env)* (.*)/if test -n "\$$2"; set -eg $2; end/; s/=/ /; s/$/;/;' "$PERLBREW_HOME/init" | source
 end
 
 if test -z "$PERLBREW_ROOT"


### PR DESCRIPTION
Current perlbrew occurred the bellow errors on fish v3.1.2.
I fixed that errors.

```
$ source ~/perl5/perlbrew/etc/perlbrew.fish
set: Invalid combination of options

~/perl5/perlbrew/etc/perlbrew.fish (line 1):
set -xg PERL5LIB "/Users/gucchi/perl5/lib/perl5"; set -eug PERLBREW_LIB; set -xg PERLBREW_MANPATH "/Users/gucchi/perl5/perlbrew/perls/perl-5.8.9/man"; set -xg PERLBREW_PATH "/Users/gucchi/perl5/perlbrew/bin /Users/gucchi/perl5/perlbrew/perls/perl-5.8.9/bin"; set -xg PERLBREW_PERL "perl-5.8.9"; set -xg PERLBREW_ROOT "/Users/gucchi/perl5/perlbrew"; set -xg PERLBREW_VERSION "0.89"; set -eug PERL_LOCAL_LIB_ROOT;
                                                  ^
in function '__perlbrew_set_env' with arguments 'perl-5.8.9'
	called on line 50 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function '__perlbrew_activate'
	called on line 138 of file ~/perl5/perlbrew/etc/perlbrew.fish
from sourcing file ~/perl5/perlbrew/etc/perlbrew.fish

(Type 'help set' for related documentation)
set: Invalid combination of options

~/perl5/perlbrew/etc/perlbrew.fish (line 1):
set -xg PERL5LIB "/Users/gucchi/perl5/lib/perl5"; set -eug PERLBREW_LIB; set -xg PERLBREW_MANPATH "/Users/gucchi/perl5/perlbrew/perls/perl-5.8.9/man"; set -xg PERLBREW_PATH "/Users/gucchi/perl5/perlbrew/bin /Users/gucchi/perl5/perlbrew/perls/perl-5.8.9/bin"; set -xg PERLBREW_PERL "perl-5.8.9"; set -xg PERLBREW_ROOT "/Users/gucchi/perl5/perlbrew"; set -xg PERLBREW_VERSION "0.89"; set -eug PERL_LOCAL_LIB_ROOT;
                                                                                                                                                                                                                                                                                                                                                                                              ^
in function '__perlbrew_set_env' with arguments 'perl-5.8.9'
	called on line 50 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function '__perlbrew_activate'
	called on line 138 of file ~/perl5/perlbrew/etc/perlbrew.fish
from sourcing file ~/perl5/perlbrew/etc/perlbrew.fish

(Type 'help set' for related documentation)
```

```
$ perlbrew switch perl-5.32.0                                                                                                                                                                                                                                          金  1/15 14:24:34 2021
set: Invalid combination of options

~/perl5/perlbrew/etc/perlbrew.fish (line 1):
set -xg PERL5LIB "/Users/gucchi/perl5/lib/perl5"; set -eug PERLBREW_LIB; set -xg PERLBREW_MANPATH "/Users/gucchi/perl5/perlbrew/perls/perl-5.32.0/man"; set -xg PERLBREW_PATH "/Users/gucchi/perl5/perlbrew/bin /Users/gucchi/perl5/perlbrew/perls/perl-5.32.0/bin"; set -xg PERLBREW_PERL "perl-5.32.0"; set -xg PERLBREW_ROOT "/Users/gucchi/perl5/perlbrew"; set -xg PERLBREW_VERSION "0.89"; set -eug PERL_LOCAL_LIB_ROOT;
                                                  ^
in function '__perlbrew_set_env' with arguments 'perl-5.32.0'
	called on line 82 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function 'perlbrew' with arguments 'use perl-5.32.0'
	called on line 92 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function 'perlbrew' with arguments 'switch perl-5.32.0'

(Type 'help set' for related documentation)
set: Invalid combination of options

~/perl5/perlbrew/etc/perlbrew.fish (line 1):
set -xg PERL5LIB "/Users/gucchi/perl5/lib/perl5"; set -eug PERLBREW_LIB; set -xg PERLBREW_MANPATH "/Users/gucchi/perl5/perlbrew/perls/perl-5.32.0/man"; set -xg PERLBREW_PATH "/Users/gucchi/perl5/perlbrew/bin /Users/gucchi/perl5/perlbrew/perls/perl-5.32.0/bin"; set -xg PERLBREW_PERL "perl-5.32.0"; set -xg PERLBREW_ROOT "/Users/gucchi/perl5/perlbrew"; set -xg PERLBREW_VERSION "0.89"; set -eug PERL_LOCAL_LIB_ROOT;
                                                                                                                                                                                                                                                                                                                                                                                                 ^
in function '__perlbrew_set_env' with arguments 'perl-5.32.0'
	called on line 82 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function 'perlbrew' with arguments 'use perl-5.32.0'
	called on line 92 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function 'perlbrew' with arguments 'switch perl-5.32.0'

(Type 'help set' for related documentation)
fish: Unknown command: unsetenv
- (line 2):
unsetenv PERLBREW_LIB;
^
from sourcing file -
	called on line 113 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function '__source_init'
	called on line 10 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function '__perlbrew_reinit' with arguments 'perl-5.32.0'
	called on line 94 of file ~/perl5/perlbrew/etc/perlbrew.fish
in function 'perlbrew' with arguments 'switch perl-5.32.0'
```
