### PR TITLE
let clone-modules  command support --notest option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 	- Fix a message mentioning fish config. GitHub PR #712
 	- Fetch cperl releases from https://github.com/perl11/cperl/releases instead
-        - Let `clone-modules` command accept `--notest` and skip running module tests
+	- Let `clone-modules` command accept `--notest` and skip running module tests
 
 0.91
 	- Released at 2021-01-31T17:10:27+0900

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 	- Fix a message mentioning fish config. GitHub PR #712
 	- Fetch cperl releases from https://github.com/perl11/cperl/releases instead
+        - Let `clone-modules` command accept `--notest` and skip running module tests
 
 0.91
 	- Released at 2021-01-31T17:10:27+0900

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2857,15 +2857,15 @@ sub run_command_clone_modules {
     # create a new application to 'exec' the 'cpanm'
     # with the specified module list
 
-    my $app = $class->new(
+    my @args = (
         qw(--quiet exec --with),
         $dst_perl,
-        'cpanm',
-        @modules_to_install
-        );
+        'cpanm'
+    );
+    push @args, '--notest' if $self->{notest};
+    push @args, @modules_to_install;
 
-    $app->run;
-
+    $class->new(@args)->run;
 }
 
 sub format_info_output

--- a/script/perlbrew
+++ b/script/perlbrew
@@ -640,7 +640,11 @@ which are not necessarily the I<same> module versions you had installed previous
 =head1 COMMAND: CLONE-MODULES
 
 Usage:
-    perlbrew clone-modules <src_version> <dst_version>
+    perlbrew clone-modules [options] <src_version> <dst_version>
+
+Options:
+
+    --notest    Skip all module tests
 
 This command re-installs all CPAN modules found from one installation to another. For example, this list all modules under '5.26.1' and re-install them under '5.27.7':
 

--- a/t/command-clone-modules.t
+++ b/t/command-clone-modules.t
@@ -1,0 +1,104 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+BEGIN { $ENV{SHELL} = "/bin/bash" }
+
+use FindBin;
+use lib $FindBin::Bin;
+use App::perlbrew;
+require "test_helpers.pl";
+
+use Test::Spec;
+
+mock_perlbrew_install("perl-5.14.1");
+mock_perlbrew_install("perl-5.16.0");
+
+no warnings;
+my ($__from, $__to, $__notest);
+sub App::perlbrew::run_command_exec {
+    my ($self, @args) = @_;
+
+    diag "ARGS: @args";
+
+    if (grep { $_ eq '-MExtUtils::Installed' } @args) {
+        $__from = $args[1];
+
+        my ($fn) = $args[5] =~ m{open .+">", "(.+?)";};
+        if ($fn) {
+            open my $fh, ">", $fn;
+            print $fh "Foo\nBar\n";
+            close($fh);
+        } else {
+            die "Failed to grok output path.";
+        }
+    } elsif (grep { $_ eq 'cpanm' } @args) {
+        $__to = $args[1];
+        ($__notest) = grep { $_ eq '--notest' } @{$self->{original_argv}};
+    }
+    return $self;
+}
+use warnings;
+
+describe "clone-modules command," => sub {
+    before each => sub {
+        delete $ENV{PERL_MB_OPT};
+        delete $ENV{PERL_MM_OPT};
+        delete $ENV{PERL_LOCAL_LIB_ROOT};
+        delete $ENV{PERLBREW_LIB};
+        delete $ENV{PERL5LIB};
+        $__from = undef;
+        $__to = undef;
+        $__notest = undef;
+    };
+
+    describe "when invoked with two arguments, A and B", sub {
+        it "should display clone modules from A to B", sub {
+            my $app = App::perlbrew->new(
+                "clone-modules", "perl-5.14.1", "perl-5.16.0"
+            );
+            $app->run;
+            is $__from, "perl-5.14.1";
+            is $__to, "perl-5.16.0";
+            ok(!defined($__notest));
+        };
+    };
+
+    describe "when invoked with two arguments, A and B, with `--notest`", sub {
+        it "should display clone modules from A to B", sub {
+            my $app = App::perlbrew->new(
+                "clone-modules", "--notest", "perl-5.14.1", "perl-5.16.0"
+            );
+            $app->run;
+            is $__from, "perl-5.14.1";
+            is $__to, "perl-5.16.0";
+            ok(defined($__notest));
+        };
+    };
+
+    describe "when invoked with one argument X", sub {
+        it "should display clone modules from current-perl to X", sub {
+            my $app = App::perlbrew->new("clone-modules", "perl-5.14.1");
+            $app->expects("current_env")->returns("perl-5.16.0")->at_least(1);
+            $app->run;
+
+            is $__from, "perl-5.16.0";
+            is $__to, "perl-5.14.1";
+            ok(!defined($__notest));
+        };
+    };
+
+    describe "when invoked with one argument X, with `--notest`", sub {
+        it "should display clone modules from current-perl to X", sub {
+            my $app = App::perlbrew->new("clone-modules", "--notest", "perl-5.14.1");
+            $app->expects("current_env")->returns("perl-5.16.0")->at_least(1);
+            $app->run;
+
+            is $__from, "perl-5.16.0";
+            is $__to, "perl-5.14.1";
+            ok(defined($__notest));
+        };
+    };
+};
+
+runtests unless caller;


### PR DESCRIPTION
Adding `--notest` means skipping all module tests.

Resolves #713