### PR TITLE
exec: do not exclude aliases whet they are specified in `--with`

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 	- Let `clone-modules` takes just one arguments and mean 'cloning modules from that perl'.
 	- Let `list-modules` and `clone-modules` map certain output to their representative module name. Github issue #722
+        - `exec` command now takes aliases explicitly specified in `--with` args and run commands with those aliases -- even if that would run the same thing twice. Github issue #725
 
 0.92
 	- Released at 2021-04-15T23:53:55+0900

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 	- Let `clone-modules` takes just one arguments and mean 'cloning modules from that perl'.
 	- Let `list-modules` and `clone-modules` map certain output to their representative module name. Github issue #722
-        - `exec` command now takes aliases explicitly specified in `--with` args and run commands with those aliases -- even if that would run the same thing twice. Github issue #725
+	- `exec` command now takes aliases explicitly specified in `--with` args and run commands with those aliases -- even if that would run the same thing twice. Github issue #725
 
 0.92
 	- Released at 2021-04-15T23:53:55+0900

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2304,7 +2304,9 @@ sub run_command_exec {
 
         @exec_with = map { $installed{$_} } @with;
     } else {
-        @exec_with = map { ($_, @{$_->{libs}}) } $self->installed_perls;
+        @exec_with = grep {
+            not -l $self->root->perls( $_->{name} ); # Skip Aliases
+        } map { ($_, @{$_->{libs}}) } $self->installed_perls;
     }
 
     if ($opts{min}) {
@@ -2328,7 +2330,6 @@ sub run_command_exec {
 
     my $overall_success = 1;
     for my $i ( @exec_with ) {
-        next if -l $self->root->perls ($i->{name}); # Skip Aliases
         my %env = $self->perlbrew_env($i->{name});
         next if !$env{PERLBREW_PERL};
 


### PR DESCRIPTION
The reason why we exclude aliases in `exec` is to avoid duplicate
run. However, if users explicitly specify aliasses in `--with`,
skipping those would be counter-intuitive.

PR: https://github.com/gugod/App-perlbrew/issues/725