### PR TITLE
unset NO_COLOR env var when building.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1675,7 +1675,7 @@ INSTALL
         $cmd = "($cmd) >> '$self->{log_file}' 2>&1 ";
     }
 
-    delete $ENV{$_} for qw(PERL5LIB PERL5OPT AWKPATH);
+    delete $ENV{$_} for qw(PERL5LIB PERL5OPT AWKPATH NO_COLOR);
 
     if ($self->do_system($cmd)) {
         my $newperl = $self->root->perls ($installation_name)->perl;


### PR DESCRIPTION
Setting NO_COLOR=1 would lead to test failures for a few modules in corelist.

This var changes the behaviour of Term::ANSIColor module in corelist
since version 5.01 and make it produce no colors code at all.

the "podlator" moduled included in perl dist contain tests that
verifies the existence of certain color codes and therefore would
break when NO_COLOR is set.

see also: https://github.com/gugod/App-perlbrew/issues/737

Fixes #737