### PR TITLE
Let `install` hint the user to do `init`.

### DIFF
--- a/lib/App/Perlbrew/Path.pm
+++ b/lib/App/Perlbrew/Path.pm
@@ -38,6 +38,12 @@ sub new {
     bless { path => _joinpath (@path) }, $class;
 }
 
+sub exists {
+    my ($self) = @_;
+
+    -e $self->stringify;
+}
+
 sub basename {
     my ($self, $suffix) = @_;
 

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1284,7 +1284,6 @@ sub run_command_install {
 
     unless ($self->root->exists) {
         die("ERROR: perlbrew root " . $self->root . " does not exist. Run `perlbrew init` to prepare it first.\n");
-        exit(-1);
     }
 
     unless ($dist) {

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1282,6 +1282,11 @@ sub do_install_release {
 sub run_command_install {
     my ($self, $dist, $opts) = @_;
 
+    unless ($self->root->exists) {
+        die("ERROR: perlbrew root " . $self->root . " does not exist. Run `perlbrew init` to prepare it first.\n");
+        exit(-1);
+    }
+
     unless ($dist) {
         $self->run_command_help("install");
         exit(-1);

--- a/t/12.destdir.t
+++ b/t/12.destdir.t
@@ -12,12 +12,6 @@ my $DESTDIR = tempdir( CLEANUP => 1 );
 
 use Test::More;
 
-## setup
-
-App::Perlbrew::Path
-    ->new($ENV{PERLBREW_ROOT})
-    ->rmpath;
-
 ## mock
 
 no warnings 'redefine';

--- a/t/12.sitecustomize.t
+++ b/t/12.sitecustomize.t
@@ -11,12 +11,6 @@ $ENV{PERLBREW_ROOT} = $App::perlbrew::PERLBREW_ROOT;
 
 use Test::More;
 
-## setup
-
-App::Perlbrew::Path
-    ->new ($ENV{PERLBREW_ROOT})
-    ->rmpath;
-
 ## mock
 
 no warnings 'redefine';

--- a/t/error-install-before-init.t
+++ b/t/error-install-before-init.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use File::Temp qw(tempdir);
+
+use App::perlbrew;
+use App::Perlbrew::Path;
+
+my $fakehome = tempdir( CLEANUP => 1 );
+
+$ENV{PERLBREW_ROOT} = $App::perlbrew::PERLBREW_ROOT = App::Perlbrew::Path->new($fakehome)->child("perl5")->stringify;
+
+throws_ok(
+    sub {
+        my $app = App::perlbrew->new("install", "perl-5.36.0");
+        $app->run;
+    },
+    qr[ERROR: .*perlbrew init.*]
+);
+
+done_testing;


### PR DESCRIPTION
... if PERLBREW_ROOT is missing.

Fixes [RT-57669]

[RT-57669]: https://rt.cpan.org/Ticket/Display.html?id=57669

When `perlbrew install $something` is run before PERLBREW_ROOT (`~/perl5`) is made, now it should show the following error message to kindly request user to run `perlbrew init`once

```
# PERLBREW_ROOT=/tmp/nonexist perlbrew install perl-5.37.2
ERROR: perlbrew root /tmp/nonexist does not exist. Run `perlbrew init` to prepare it first.
```
