### PR TITLE
remove Pod::Parser dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,8 +3,7 @@ requires 'CPAN::Perl::Releases' => '5.20220720';
 requires 'Devel::PatchPerl'     => '2.08';
 
 requires 'Capture::Tiny'        => '0.48';
-requires 'Pod::Parser'          => '1.63';
-requires 'Pod::Usage'           => '1.68';
+requires 'Pod::Usage'           => '1.69';
 requires 'File::Copy'           => '0';
 requires 'File::Temp'           => '0.2304';
 requires 'JSON::PP'             => '0';


### PR DESCRIPTION
Pod::Parser was only used via Pod::Usage, but it has been ported to only
use Pod::Simple. Versions of Pod::Usage prior to 1.69 still had some
reliance on Pod::Parser in their tests, so bump the Pod::Usage prereq to
the first version that was completely independant.