### PR TITLE
quote MANPATH in cshrc

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -3216,9 +3216,9 @@ setenv PATH "${PERLBREW_PATH}:${PATH_WITHOUT_PERLBREW}"
 
 setenv MANPATH_WITHOUT_PERLBREW `perl -e 'print join ":", grep { index($_, $ENV{PERLBREW_ROOT}) } split/:/,qx(manpath 2> /dev/null);'`
 if ( $?PERLBREW_MANPATH == 1 ) then
-    setenv MANPATH ${PERLBREW_MANPATH}:${MANPATH_WITHOUT_PERLBREW}
+    setenv MANPATH "${PERLBREW_MANPATH}:${MANPATH_WITHOUT_PERLBREW}"
 else
-    setenv MANPATH ${MANPATH_WITHOUT_PERLBREW}
+    setenv MANPATH "${MANPATH_WITHOUT_PERLBREW}"
 endif
 SETPATH
 }


### PR DESCRIPTION
This fixes the "setenv: Too many arguments" error when MANPATH contains spaces.