### PR TITLE
make-pp: include privlib

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2796,6 +2796,13 @@ sub run_command_make_pp {
         'print $Config{sitelibexp}',
     );
 
+    my $privlib = $self->do_capture(
+        $self->installed_perl_executable( $self->current_perl ),
+        "-MConfig",
+        "-e",
+        'print $Config{privlibexp}',
+    );
+
     my $locallib;
     if ($self->current_lib) {
         require local::lib;
@@ -2815,6 +2822,7 @@ sub run_command_make_pp {
     my @cmd = (
         $path_pp,
         "-B", # core modules
+        "-a", "$privlib;$perlversion",
         "-a", "$sitelib;$perlversion",
         ($locallib ? ("-a", "$locallib;$perlversion") : ()),
         "-z", "9",

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2802,10 +2802,9 @@ sub run_command_make_pp {
         'print $Config{sitelibexp}',
     );
 
-    my $privlib = $self->do_capture(
-        $self->installed_perl_executable( $self->current_perl ),
-        "-MConfig",
-        "-e",
+    my $privlib = $self->do_capture_current_perl(
+        '-MConfig',
+        '-e',
         'print $Config{privlibexp}',
     );
 


### PR DESCRIPTION
privlib contains all core libs and therefore should be part of the output.
