### PR TITLE
Nixos (and others) compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.99
+	- Thanks to our contributors: Joelle Maslak
+	- bashrc executes properly in bash shells with +h option set
+
 0.98
 	- Released at 2023-08-11T22:54:38+0900
 	- Remove the support of cperl from `available` and `install` command. Github PR: #777. cperl can still be installed by specifying the tarball, just not by their short names.

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 0.99
 	- Thanks to our contributors: Joelle Maslak
 	- bashrc executes properly in bash shells with +h option set
+	- Allow specification of non-standard Perl location
 
 0.98
 	- Released at 2023-08-11T22:54:38+0900

--- a/META.json
+++ b/META.json
@@ -49,7 +49,8 @@
             "Test::Output" : "1.03",
             "Test::Simple" : "1.001002",
             "Test::Spec" : "0.49",
-            "Test::TempDir::Tiny" : "0.016"
+            "Test::TempDir::Tiny" : "0.016",
+            "Test::Which" : "1.27"
          }
       }
    },

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2881,7 +2881,9 @@ __perlbrew_purify () {
 __perlbrew_set_path () {
     export MANPATH=${PERLBREW_MANPATH:-}${PERLBREW_MANPATH:+:}$(__perlbrew_purify "$(manpath 2>/dev/null)")
     export PATH=${PERLBREW_PATH:-$PERLBREW_ROOT/bin}:$(__perlbrew_purify "$PATH")
-    hash -r
+    if [ -o hashall ] ; then
+        hash -r
+    fi
 }
 
 __perlbrew_set_env() {

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -3433,6 +3433,11 @@ As a result, different users on the same machine can all share the same perlbrew
 root directory (although only original user that made the installation would
 have the permission to perform perl installations.)
 
+If you need to install perlbrew using a Perl that isn't either C</usr/bin/perl>
+or C</usr/local/bin/perl>, set and export the environment variable
+C<PERLBREW_SYSTEM_PERL> and then install as described above. Note that you
+must not use a perlbrew-managed perl.
+
 You may also install perlbrew from CPAN:
 
     cpan App::perlbrew

--- a/perlbrew-install
+++ b/perlbrew-install
@@ -42,13 +42,14 @@ echo
 echo "## Installing perlbrew"
 
 # loop thru available well known Perl installations
-for PERL in "/usr/bin/perl" "/usr/local/bin/perl"
+for PERL in "/usr/bin/perl" "/usr/local/bin/perl" "$PERLBREW_SYSTEM_PERL"
 do
-    [ -x "$PERL" ] && echo "Using Perl <$PERL>" && break
+    [ -n "$PERL" ] && [ -x "$PERL" ] && echo "Using Perl <$PERL>" && break
 done
 
 if [ ! -x "$PERL" ]; then
   echo "Need /usr/bin/perl or /usr/local/bin/perl to use $0"
+  echo "Alternatively, set PERLBREW_SYSTEM_PERL to point at system perl"
   clean_exit 2
 fi
 

--- a/t/bashrc_executes.t
+++ b/t/bashrc_executes.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib $FindBin::Bin;
+use App::perlbrew;
+require 'test_helpers.pl';
+
+use Test::More;
+use Capture::Tiny qw( capture_stderr );
+use File::Which qw( which );
+
+note "PERLBREW_ROOT set to $ENV{PERLBREW_ROOT}";
+
+subtest "Works without error output on bash where hashing is off", sub {
+    my $bash = which("bash");
+    if (!defined($bash)) {
+        plan skip_all => "Bash executable not found, skipping this test.";
+        return;
+    }
+
+    my $app = App::perlbrew->new('self-install');
+    $app->current_shell("bash");
+    $app->run;
+
+    my $ret;
+    my $out = capture_stderr {
+        my $bash_init = file($ENV{PERLBREW_ROOT}, "etc", "bashrc");
+        system("ls $ENV{PERLBREW_ROOT}/etc/bashrc");
+        $ret = system($bash, "+h", "-c", "source $bash_init");
+    };
+    is($out, "", "No error messages in output");
+    is($ret, 0, "Return value proper");
+};
+
+
+done_testing;


### PR DESCRIPTION
NixOS does not install a system Perl in a standard location (it uses either a global perl in `/run/current-system/sw/bin` or a Perl in the `/nix/store/* tree`.  This patch allows someone to add an additional system perl library location via the `PERLBREW_SYSTEM_PERL` environmental variable.

In addition, NixOS configures the user's bash shell with the hashall option off.  The bashrc file in Perlbrew executes `hash -r` which fails because hashing is disabled. This patch adds a check of the hashall option before attempting to clear the hash cache.

I'm open to any changes you might desire to accept this PR.