### PR TITLE
work with distdir instead of tarball.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
   cpanm-dist:
     needs: mbtiny-dist
-
+    steps:
       - uses: actions/download-artifact@v4
         with:
           name: App-perlbrew-distdir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,43 +10,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cpanm --quiet --notest App::ModuleBuildTiny
-      - run: mbtiny dist
-      - run: echo ./App-perlbrew-*.tar.gz
+      - run: mbtiny distdir
+      - run: echo ./App-perlbrew-*
       - uses: actions/upload-artifact@v4
         with:
-          name: App-perlbrew-tarball
-          path: ./App-perlbrew-*.tar.gz
+          name: App-perlbrew-distdir
+          path: ./App-perlbrew-*
           retention-days: 5
 
   cpanm-dist:
     needs: mbtiny-dist
-    strategy:
-      matrix:
-        version: ["5.38", "5.36", "5.34", "5.18"]
-    name: cpanm-dist-perl-${{ matrix.version }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: shogo82148/actions-setup-perl@v1.29.0
-        with:
-          perl-version: ${{ matrix.version }}
-      - uses: actions/download-artifact@v4
-        with:
-          name: App-perlbrew-tarball
-      - run: echo ./App-perlbrew-*.tar.gz
-      - run: cpanm --verbose ./App-perlbrew-*.tar.gz
 
-  cpanm-dist-in-container:
-    needs: mbtiny-dist
-    strategy:
-      matrix:
-        version: ["5.39"]
-    name: cpanm-dist-perl-${{ matrix.version }}
-    runs-on: ubuntu-latest
-    container:
-      image: perl:${{ matrix.version }}
-    steps:
       - uses: actions/download-artifact@v4
         with:
-          name: App-perlbrew-tarball
-      - run: echo ./App-perlbrew-*.tar.gz
-      - run: cpanm --verbose ./App-perlbrew-*.tar.gz
+          name: App-perlbrew-distdir
+      - run: echo ./App-perlbrew-*
+      - run: cpanm --verbose ./App-perlbrew-*


### PR DESCRIPTION
Not sure what part of github workflow has changed, but having a tarball in artifact (which itself is a zip-archive) would lead us to a weird situation that the name of the directory instide the tarball becomes the the as the the tarballs itself, and makes `tar xfz` always fails.

I guess it can be bypassed by avoid making a tarball in the first place.