### PR TITLE
Replace Testt::Spec with Test2::Tools::Spec

### DIFF
--- a/META.json
+++ b/META.json
@@ -50,7 +50,6 @@
             "Test::NoWarnings" : "1.04",
             "Test::Output" : "1.03",
             "Test::Simple" : "1.001002",
-            "Test::Spec" : "0.49",
             "Test::TempDir::Tiny" : "0.016"
          }
       }

--- a/META.yml
+++ b/META.yml
@@ -13,7 +13,6 @@ build_requires:
   Test::NoWarnings: '1.04'
   Test::Output: '1.03'
   Test::Simple: '1.001002'
-  Test::Spec: '0.49'
   Test::TempDir::Tiny: '0.016'
 configure_requires:
   Module::Build::Tiny: '0.039'

--- a/cpanfile
+++ b/cpanfile
@@ -19,7 +19,6 @@ on test => sub {
     requires 'Test::NoWarnings'     => '1.04';
     requires 'Test::Output'         => '1.03';
     requires 'Test::Simple'         => '1.001002';
-    requires 'Test::Spec'           => '0.49';
     requires 'Test::TempDir::Tiny'  => '0.016';
     requires 'Test2::V0'            => '0.000163';
     requires 'Test2::Plugin::NoWarnings' => '0.10';

--- a/t/app-perlbrew-path-installation.t
+++ b/t/app-perlbrew-path-installation.t
@@ -4,8 +4,6 @@ use Test2::Tools::Spec;
 
 use File::Temp qw[];
 
-use Test::Deep;
-
 use App::Perlbrew::Path::Root;
 use App::Perlbrew::Path::Installation;
 use App::Perlbrew::Path::Installations;
@@ -22,8 +20,7 @@ describe "App::Perlbrew::Path::Root" => sub {
             it "should return Instalations object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls;
-
-                cmp_deeply $path, looks_like_perl_installations("~/.root/perls");
+                is $path, looks_like_perl_installations("~/.root/perls");
             };
         };
 
@@ -31,17 +28,14 @@ describe "App::Perlbrew::Path::Root" => sub {
             it "should return Installation object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls('blead');
-
-                cmp_deeply $path, looks_like_perl_installation("~/.root/perls/blead");
+                is $path, looks_like_perl_installation("~/.root/perls/blead");
             };
         };
 
         describe "with multiple paramters" => sub {
-            it "should return Path object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls('blead', '.version');
-
-                cmp_deeply $path, looks_like_path("~/.root/perls/blead/.version");
+                is $path, looks_like_path("~/.root/perls/blead/.version");
             };
         }
     };
@@ -57,7 +51,7 @@ describe "App::Perlbrew::Path::Installations" => sub {
 
             my @list = $root->perls->list;
 
-            cmp_deeply \@list, [
+            is \@list, [
                 looks_like_perl_installation("~/.root/perls/perl-1"),
                 looks_like_perl_installation("~/.root/perls/perl-2"),
             ];
@@ -70,22 +64,19 @@ describe "App::Perlbrew::Path::Installation" => sub {
         it "should return installation name" => sub {
             local $ENV{HOME};
             my $installation = arrange_installation('foo-bar');
-
-            cmp_deeply $installation->name, 'foo-bar';
+            is $installation->name, 'foo-bar';
         };
 
         it "should provide path to perl" => sub {
             local $ENV{HOME};
             my $perl = arrange_installation('foo-bar')->perl;
-
-            cmp_deeply $perl->stringify_with_tilde, '~/.root/perls/foo-bar/bin/perl';
+            is $perl->stringify_with_tilde, '~/.root/perls/foo-bar/bin/perl';
         };
 
         it "should provide path to version file" => sub {
             local $ENV{HOME};
             my $file = arrange_installation('foo-bar')->version_file;
-
-            cmp_deeply $file->stringify_with_tilde, '~/.root/perls/foo-bar/.version';
+            is $file->stringify_with_tilde, '~/.root/perls/foo-bar/.version';
         };
     };
 };
@@ -100,19 +91,18 @@ sub looks_like_path {
     : 'stringify'
     ;
 
-    all(
-        methods($method => $path),
-        Isa('App::Perlbrew::Path'),
-        @tests,
-    );
+    object {
+        call $method => $path;
+        prop isa => 'App::Perlbrew::Path';
+    };
 }
 
 sub looks_like_perl_installation {
-    looks_like_path(@_, Isa('App::Perlbrew::Path::Installation'));
+    looks_like_path(@_, object { prop isa => 'App::Perlbrew::Path::Installation' });
 }
 
 sub looks_like_perl_installations {
-    looks_like_path(@_, Isa('App::Perlbrew::Path::Installations'));
+    looks_like_path(@_, object { prop isa => 'App::Perlbrew::Path::Installation' });
 }
 
 sub arrange_root {

--- a/t/app-perlbrew-path-installation.t
+++ b/t/app-perlbrew-path-installation.t
@@ -1,10 +1,9 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
 
 use File::Temp qw[];
 
-use Test::Spec;
 use Test::Deep;
 
 use App::Perlbrew::Path::Root;
@@ -19,7 +18,7 @@ sub arrange_installation;
 
 describe "App::Perlbrew::Path::Root" => sub {
     describe "perls()" => sub {
-        context "without parameters" => sub {
+        describe "without parameters" => sub {
             it "should return Instalations object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls;
@@ -28,7 +27,7 @@ describe "App::Perlbrew::Path::Root" => sub {
             };
         };
 
-        context "with one parameter" => sub {
+        describe "with one parameter" => sub {
             it "should return Installation object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls('blead');
@@ -37,7 +36,7 @@ describe "App::Perlbrew::Path::Root" => sub {
             };
         };
 
-        context "with multiple paramters" => sub {
+        describe "with multiple paramters" => sub {
             it "should return Path object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls('blead', '.version');
@@ -91,7 +90,7 @@ describe "App::Perlbrew::Path::Installation" => sub {
     };
 };
 
-runtests unless caller;
+done_testing;
 
 sub looks_like_path {
     my ($path, @tests) = @_;

--- a/t/app-perlbrew-path-installation.t
+++ b/t/app-perlbrew-path-installation.t
@@ -33,6 +33,7 @@ describe "App::Perlbrew::Path::Root" => sub {
         };
 
         describe "with multiple paramters" => sub {
+            it "should return Path object" => sub {
                 local $ENV{HOME};
                 my $path = arrange_root->perls('blead', '.version');
                 is $path, looks_like_path("~/.root/perls/blead/.version");

--- a/t/command-alias.t
+++ b/t/command-alias.t
@@ -1,16 +1,14 @@
 #!/usr/bin/env perl
-#!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
 
 BEGIN { $ENV{SHELL} = "/bin/bash" }
 
 use FindBin;
 use lib $FindBin::Bin;
 use App::perlbrew;
-require "test_helpers.pl";
+require "test2_helpers.pl";
 
-use Test::Spec;
 use Test::Output;
 use Config;
 
@@ -18,7 +16,7 @@ mock_perlbrew_install("perl-5.14.1");
 mock_perlbrew_lib_create('perl-5.14.1@nobita');
 
 describe "alias command," => sub {
-    before each => sub {
+    before_each 'cleanup env' => sub {
         delete $ENV{PERL_MB_OPT};
         delete $ENV{PERL_MM_OPT};
         delete $ENV{PERL_LOCAL_LIB_ROOT};
@@ -44,4 +42,4 @@ describe "alias command," => sub {
     };
 };
 
-runtests unless caller;
+done_testing;

--- a/t/command-available.t
+++ b/t/command-available.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
-use Test::Spec;
+use Test2::V0;
+use Test2::Tools::Spec;
 use File::Temp qw( tempdir );
 use Test::Output;
 
@@ -28,13 +27,18 @@ my %available_perl_dists = (
 
 sub mocked_perlbrew {
     my $app = App::perlbrew->new( @_ );
-    $app->expects( 'available_perl_distributions' )->returns( \%available_perl_dists );
-    return $app;
+
+    my $mock = mock $app,
+        override => [
+            available_perl_distributions => sub { \%available_perl_dists }
+        ];
+
+    return ($mock, $app);
 }
 
 describe "available command output, when nothing installed locally," => sub {
     it "should display a list of perl versions" => sub {
-        my $app = mocked_perlbrew( "available", "--verbose" );
+        my ($mock, $app) = mocked_perlbrew( "available", "--verbose" );
 
         stdout_like sub {
             $app->run();
@@ -60,14 +64,16 @@ describe "available command output, when nothing installed locally," => sub {
 
 describe "available command output, when something installed locally," => sub {
     it "should display a list of perl versions, with markers on installed versions" => sub {
-        my $app = mocked_perlbrew( "available", "--verbose" );
+        my ($mock, $app) = mocked_perlbrew( "available", "--verbose" );
 
         my @installed_perls = (
             { name => "perl-5.24.0" },
             { name => "perl-5.20.3" }
         );
 
-        $app->expects("installed_perls")->returns(@installed_perls);
+        $mock->override(
+            "installed_perls" => sub  { @installed_perls }
+        );
 
         stdout_like sub {
             $app->run();
@@ -94,4 +100,4 @@ describe "available command output, when something installed locally," => sub {
     };
 };
 
-runtests unless caller;
+done_testing;

--- a/t/command-clone-modules.t
+++ b/t/command-clone-modules.t
@@ -1,15 +1,13 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
 
 BEGIN { $ENV{SHELL} = "/bin/bash" }
 
 use FindBin;
 use lib $FindBin::Bin;
 use App::perlbrew;
-require "test_helpers.pl";
-
-use Test::Spec;
+require "test2_helpers.pl";
 
 mock_perlbrew_install("perl-5.14.1");
 mock_perlbrew_install("perl-5.16.0");
@@ -33,7 +31,7 @@ sub App::perlbrew::run_command_exec {
 use warnings;
 
 describe "clone-modules command," => sub {
-    before each => sub {
+    before_each 'cleanup env' => sub {
         delete $ENV{PERL_MB_OPT};
         delete $ENV{PERL_MM_OPT};
         delete $ENV{PERL_LOCAL_LIB_ROOT};
@@ -71,26 +69,30 @@ describe "clone-modules command," => sub {
     describe "when invoked with one argument X", sub {
         it "should display clone modules from current-perl to X", sub {
             my $app = App::perlbrew->new("clone-modules", "perl-5.14.1");
-            $app->expects("current_env")->returns("perl-5.16.0")->at_least(1);
+
+            my $mock = mocked($app)->expects("current_env")->returns("perl-5.16.0")->at_least(1);
             $app->run;
 
             is $__from, "perl-5.16.0";
             is $__to, "perl-5.14.1";
             ok(!defined($__notest));
+
+            $mock->verify;
         };
     };
 
     describe "when invoked with one argument X, with `--notest`", sub {
         it "should display clone modules from current-perl to X", sub {
             my $app = App::perlbrew->new("clone-modules", "--notest", "perl-5.14.1");
-            $app->expects("current_env")->returns("perl-5.16.0")->at_least(1);
+            my $mock = mocked($app)->expects("current_env")->returns("perl-5.16.0")->at_least(1);
             $app->run;
 
             is $__from, "perl-5.16.0";
             is $__to, "perl-5.14.1";
             ok(defined($__notest));
+            $mock->verify;
         };
     };
 };
 
-runtests unless caller;
+done_testing;

--- a/t/command-compgen.t
+++ b/t/command-compgen.t
@@ -1,13 +1,12 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
 
 use FindBin;
 use lib $FindBin::Bin;
 use App::perlbrew;
-require "test_helpers.pl";
+require "test2_helpers.pl";
 
-use Test::Spec;
 use Test::Output qw( stdout_from );
 
 $ENV{PERLBREW_DEBUG_COMPLETION} = 0;
@@ -84,5 +83,4 @@ describe "compgen command," => sub {
     }
 };
 
-runtests unless caller;
-
+done_testing;

--- a/t/command-env.t
+++ b/t/command-env.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
 
 BEGIN { $ENV{SHELL} = "/bin/bash" }
 
 use FindBin;
 use lib $FindBin::Bin;
 use App::perlbrew;
-require "test_helpers.pl";
+require "test2_helpers.pl";
 
-use Test::Spec;
 use Test::Output;
 use Config;
 
@@ -17,7 +16,7 @@ mock_perlbrew_install("perl-5.14.1");
 mock_perlbrew_lib_create('perl-5.14.1@nobita');
 
 describe "env command," => sub {
-    before each => sub {
+    before_each 'cleanup env' => sub {
         delete $ENV{PERL_MB_OPT};
         delete $ENV{PERL_MM_OPT};
         delete $ENV{PERL_LOCAL_LIB_ROOT};
@@ -98,4 +97,4 @@ OUT
     }
 };
 
-runtests unless caller;
+done_testing;

--- a/t/command-exec.t
+++ b/t/command-exec.t
@@ -1,12 +1,12 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
+
 use FindBin;
 use lib $FindBin::Bin;
 use App::perlbrew;
-require 'test_helpers.pl';
+require 'test2_helpers.pl';
 
-use Test::Spec;
 use Test::Output;
 
 mock_perlbrew_install("perl-5.12.3");
@@ -16,261 +16,365 @@ mock_perlbrew_install("perl-5.14.2");
 
 describe 'perlbrew exec perl -E "say 42"' => sub {
     it "invokes all perls" => sub {
-        my $app = App::perlbrew->new(qw(exec perl -E), "say 42");
-
-        my @perls = $app->installed_perls;
-
-        $app->expects("do_system_with_exit_code")->exactly(4)->returns(
+        mocked(
+            App::perlbrew->new(qw(exec perl -E), "say 42"),
             sub {
-                my ($self, @args) = @_;
+                my ($mock, $app) = @_;
 
-                is_deeply \@args, ["perl", "-E", "say 42"];
+                my @perls = $app->installed_perls;
 
-                my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
+                $mock->expects("do_system_with_exit_code")->exactly(4)->returns(
+                    sub {
+                        my ($self, @args) = @_;
 
-                my $perl_installation = shift @perls;
+                        is \@args, ["perl", "-E", "say 42"], "arguments";
 
-                is $perlbrew_bin_path,      App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "bin");
-                is $perlbrew_perl_bin_path, App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "perls", $perl_installation->{name}, "bin"), "perls/". $perl_installation->{name} . "/bin";
+                        my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
 
-                return 0;
+                        my $perl_installation = shift @perls;
+
+                        is $perlbrew_bin_path,      App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "bin")->stringify(), "perlbrew_bin_path";
+                        is $perlbrew_perl_bin_path, App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", $perl_installation->{name}, "bin")->stringify(), "perls/". $perl_installation->{name} . "/bin";
+
+                        return 0;
+                    }
+                );
+
+                $app->run;
             }
         );
-
-        $app->run;
     };
 };
 
 describe 'perlbrew exec --with perl-5.12.3 perl -E "say 42"' => sub {
     it "invokes perl-5.12.3/bin/perl" => sub {
-        my $app = App::perlbrew->new(qw(exec --with perl-5.12.3 perl -E), "say 42");
-
-        $app->expects("do_system_with_exit_code")->returns(
+        mocked(
+            App::perlbrew->new(qw(exec --with perl-5.12.3 perl -E), "say 42"),
             sub {
-                my ($self, @args) = @_;
+                my ($mock, $app) = @_;
 
-                is_deeply \@args, ["perl", "-E", "say 42"];
+                $mock->expects("do_system_with_exit_code")->returns(
+                    sub {
+                        my ($self, @args) = @_;
 
-                my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
+                        is \@args, ["perl", "-E", "say 42"];
 
-                is $perlbrew_bin_path,      App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "bin");
-                is $perlbrew_perl_bin_path, App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.3", "bin");
+                        my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
 
-                return 0;
+                        is $perlbrew_bin_path,      App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "bin")->stringify;
+                        is $perlbrew_perl_bin_path, App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.3", "bin")->stringify;
+
+                        return 0;
+                    }
+                );
+
+                $app->run;
             }
         );
-
-        $app->run;
     };
 };
 
 describe 'perlbrew exec --with perl-5.14.1,perl-5.12.3,perl-5.14.2 perl -E "say 42"' => sub {
     it "invokes each perl in the specified order" => sub {
-        my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-5.12.3 perl-5.14.2", qw(perl -E), "say 42");
-
-        my @perl_paths;
-        $app->expects("do_system_with_exit_code")->exactly(3)->returns(
+        mocked(
+            App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-5.12.3 perl-5.14.2", qw(perl -E), "say 42"),
             sub {
-                my ($self, @args) = @_;
-                my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
-                push @perl_paths, $perlbrew_perl_bin_path;
-                return 0;
+                my ($mock, $app) = @_;
+
+                my @perl_paths;
+
+                $mock->expects("do_system_with_exit_code")->exactly(3)->returns(
+                    sub {
+                        my ($self, @args) = @_;
+                        my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
+                        push @perl_paths, $perlbrew_perl_bin_path;
+                        return 0;
+                    }
+                );
+
+                $app->run;
+
+                is \@perl_paths, [
+                    App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin")->stringify,
+                    App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.3", "bin")->stringify,
+                    App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.2", "bin")->stringify,
+                ];
             }
         );
-
-        $app->run;
-
-        is_deeply \@perl_paths, [
-            App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin"),
-            App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.3", "bin"),
-            App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.2", "bin"),
-        ];
     };
 };
 
 describe 'perlbrew exec --with perl-5.14.1,perl-foobarbaz, ' => sub {
     it "ignore the unrecognized 'perl-foobarbaz'" => sub {
-        my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-foobarbaz", qw(perl -E), "say 42");
-
-        my @perl_paths;
-        $app->expects("do_system_with_exit_code")->returns(
+        mocked(
+            App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-foobarbaz", qw(perl -E), "say 42"),
             sub {
-                my ($self, @args) = @_;
-                my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
-                push @perl_paths, $perlbrew_perl_bin_path;
-                return 0;
-            }
-        );
+                my ($mock, $app) = @_;
 
-        $app->run;
+                my @perl_paths;
 
-        is_deeply \@perl_paths, [
-            App::Perlbrew::Path->new ($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin"),
-        ];
+                $mock->expects("do_system_with_exit_code")->returns(
+                    sub {
+                        my ($self, @args) = @_;
+                        my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
+                        push @perl_paths, $perlbrew_perl_bin_path;
+                        return 0;
+                    }
+                );
+
+                $app->run;
+
+                is \@perl_paths, [
+                    App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin")->stringify(),
+                ];
+            },
+        )
     };
 };
 
 describe 'perlbrew exec --with perl-5.14.1,5.14.1 ' => sub {
     it "exec 5.14.1 twice, since that is what is specified" => sub {
-        my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1 5.14.1", qw(perl -E), "say 42");
-
-        my @perl_paths;
-        $app->expects("do_system_with_exit_code")->exactly(2)->returns(
+        mocked(
+            App::perlbrew->new(qw(exec --with), "perl-5.14.1 5.14.1", qw(perl -E), "say 42"),
             sub {
-                my ($self, @args) = @_;
-                my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
-                push @perl_paths, $perlbrew_perl_bin_path;
-                return 0;
+                my ($mock, $app) = @_;
+
+                my @perl_paths;
+
+                $mock->expects("do_system_with_exit_code")->exactly(2)->returns(
+                    sub {
+                        my ($self, @args) = @_;
+                        my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
+                        push @perl_paths, $perlbrew_perl_bin_path;
+                        return 0;
+                    }
+                );
+
+                $app->run;
+
+                is \@perl_paths, [
+                    App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin")->stringify,
+                    App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin")->stringify,
+                ];
             }
-        );
-
-        $app->run;
-
-        is_deeply \@perl_paths, [
-            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin"),
-            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin"),
-        ];
+        )
     };
 };
 
 describe 'exec exit code' => sub {
     describe "logging" => sub {
         it "should work" => sub {
-            my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1", qw(perl -E), "somesub 42");
-            $app->expects("format_info_output")->exactly(1)->returns("format_info_output_value\n");
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
-                die "simulate exit\n";
-            });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(7<<8);
-            stderr_is sub {
-                eval { $app->run; 1; };
-            }, <<"OUT";
+            mocked(
+                App::perlbrew->new(qw(exec --with), "perl-5.14.1", qw(perl -E), "somesub 42"),
+                sub {
+                    my ($mock, $app) = @_;
+
+                    $mock->expects("format_info_output")->exactly(1)->returns("format_info_output_value\n");
+                    $mock->expects("do_system_with_exit_code")->exactly(1)->returns(7<<8);
+
+                    my $mock2 = mocked('App::perlbrew');
+                    $mock2->expects("do_exit_with_error_code")->exactly(1)->returns(sub { die "simulate exit\n" });
+
+                    stderr_is sub {
+                        eval { $app->run; 1; };
+                    }, <<"OUT";
 Command [perl -E 'somesub 42'] terminated with exit code 7 (\$? = 1792) under the following perl environment:
 format_info_output_value
 OUT
+
+                    $mock2->verify;
+                }
+            )
         };
+
         it "should be quiet if asked" => sub {
             my $app = App::perlbrew->new(qw(exec --quiet --with), "perl-5.14.1", qw(perl -E), "somesub 42");
-            $app->expects("format_info_output")->exactly(0)->returns('should not be called!');
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
-                die "simulate exit\n";
-            });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(7<<8);
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(0)->returns('should not be called!');
+            $mock->expects("do_system_with_exit_code")->exactly(1)->returns(7<<8);
+
+            my $mock2 = mocked('App::perlbrew');
+            $mock2->expects("do_exit_with_error_code")->exactly(1)->returns(sub { die "simulate exit\n" });
+
             stderr_is sub {
                 eval { $app->run; 1; };
             }, '';
+
+            $mock->verify;
+            $mock2->verify;
         };
+
         it "should format info output for right perl" => sub {
             my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1", qw(perl -E), "somesub 42");
-            $app->expects("format_info_output")->exactly(1)->returns(sub {
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(1)->returns(sub {
                 my ($self) = @_;
                 is $self->current_env, 'perl-5.14.1';
                 like $self->installed_perl_executable('perl-5.14.1'), qr/perl-5.14.1/;
                 "format_info_output_value\n";
             });
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
+            $mock->expects("do_system_with_exit_code")->exactly(1)->returns(7<<8);
+
+            my $mock2 = mocked('App::perlbrew');
+            $mock2->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
                 die "simulate exit\n";
             });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(7<<8);
+
             eval { $app->run; 1; };
+
+            $mock->verify;
+            $mock2->verify;
         };
     };
+
     describe "no halt-on-error" => sub {
         it "should exit with success code when several perls ran" => sub {
-            my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-5.14.1", qw(perl -E), "say 42");
-            App::perlbrew->expects("do_exit_with_error_code")->never;
-            $app->expects("do_system_with_exit_code")->exactly(2)->returns(0);
-            $app->run;
+            my $mock2 = mocked('App::perlbrew')->expects("do_exit_with_error_code")->never;
+
+            mocked(
+                App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-5.14.1", qw(perl -E), "say 42"),
+                sub {
+                    my ($mock, $app) = @_;
+                    $mock->expects("do_system_with_exit_code")->exactly(2)->returns(0);
+                    $app->run;
+                }
+            );
+
+            $mock2->verify;
         };
+
         it "should exit with error code " => sub {
             my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1", qw(perl -E), "say 42");
-            $app->expects("format_info_output")->exactly(1)->returns('');
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(1)->returns('');
+            $mock->expects("do_system_with_exit_code")->exactly(1)->returns(3<<8);
+
+            my $mock2 = mocked('App::perlbrew')->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
                 my ($self, $code) = @_;
                 is $code, 1; # exit with error, but don't propogate exact failure codes
                 die "simulate exit\n";
             });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(3<<8);
+
+
             ok !eval { $app->run; 1; };
             is $@, "simulate exit\n";
+
+            $mock->verify;
+            $mock2->verify;
         };
+
         it "should exit with error code when several perls ran" => sub {
             my $app = App::perlbrew->new(qw(exec --with), "perl-5.14.1 perl-5.14.1", qw(perl -E), "say 42");
-            $app->expects("format_info_output")->exactly(1)->returns('');
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(1)->returns('');
+            my $calls = 0;
+            $mock->expects("do_system_with_exit_code")->exactly(2)->returns(sub {
+                $calls++;
+                return 0 if ($calls == 2); # second exec call successed
+                return 3<<8; # first exec failed
+            });
+
+            my $mock2 = mocked('App::perlbrew')->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
                 my ($self, $code) = @_;
                 is $code, 1; # exit with error, but don't propogate exact failure codes
                 die "simulate exit\n";
             });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(sub {
-                $app->expects("do_system_with_exit_code")->exactly(1)->returns(sub { # make sure second call to exec is made
-                    0; # second call is success
-                });
-                3<<8; # first exec failed
-            });
+
             ok !eval { $app->run; 1; };
             is $@, "simulate exit\n";
+
+            $mock->verify;
+            $mock2->verify;
         };
     };
+
     describe "halt-on-error" => sub {
         it "should exit with success code " => sub {
             my $app = App::perlbrew->new(qw(exec --halt-on-error --with), "perl-5.14.1", qw(perl -E), "say 42");
-            App::perlbrew->expects("do_exit_with_error_code")->never;
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(0);
+            my $mock = mocked('App::perlbrew')->expects("do_exit_with_error_code")->never;
+            my $mock2 = mocked($app)->expects("do_system_with_exit_code")->exactly(1)->returns(0);
             $app->run;
+            $mock->verify;
+            $mock2->verify;
         };
+
         it "should exit with error code " => sub {
             my $app = App::perlbrew->new(qw(exec --halt-on-error --with), "perl-5.14.1", qw(perl -E), "say 42");
-            $app->expects("format_info_output")->exactly(1)->returns('');
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(1)->returns('');
+            $mock->expects("do_system_with_exit_code")->exactly(1)->returns(3<<8);
+
+            my $mock2 = mocked('App::perlbrew')->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
                 my ($self, $code) = @_;
                 is $code, 3;
                 die "simulate exit\n";
             });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(3<<8);
+
             ok !eval { $app->run; 1; };
             is $@, "simulate exit\n";
 
+            $mock->verify;
+            $mock2->verify;
         };
+
         it "should exit with code 255 if program terminated with signal or something" => sub {
             my $app = App::perlbrew->new(qw(exec --halt-on-error --with), "perl-5.14.1", qw(perl -E), "say 42");
-            $app->expects("format_info_output")->exactly(1)->returns('');
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(1)->returns('');
+            $mock->expects("do_system_with_exit_code")->exactly(1)->returns(-1);
+
+            my $mock2 = mocked('App::perlbrew')->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
                 my ($self, $code) = @_;
                 is $code, 255;
                 die "simulate exit\n";
             });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(-1);
+
             ok !eval { $app->run; 1; };
             is $@, "simulate exit\n";
 
+            $mock->verify;
+            $mock2->verify;
         };
+
         it "should exit with error code when several perls ran" => sub {
             my $app = App::perlbrew->new(qw(exec --halt-on-error --with), "perl-5.14.1 perl-5.14.1", qw(perl -E), "say 42");
-            $app->expects("format_info_output")->exactly(1)->returns('');
-            App::perlbrew->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
+
+            my $mock = mocked($app);
+            $mock->expects("format_info_output")->exactly(1)->returns('');
+            my $calls = 0;
+            $mock->expects("do_system_with_exit_code")->exactly(2)->returns(sub {
+                $calls++;
+                return 7<<8 if $calls == 2;
+                return 0;
+            });
+
+            my $mock2 = mocked('App::perlbrew')->expects("do_exit_with_error_code")->exactly(1)->returns(sub {
                 my ($self, $code) = @_;
                 is $code, 7;
                 die "simulate exit\n";
             });
-            $app->expects("do_system_with_exit_code")->exactly(1)->returns(sub {
-                $app->expects("do_system_with_exit_code")->exactly(1)->returns(sub {
-                    7<<8;
-                });
-                0;
-            });
+
             ok !eval { $app->run; 1; };
             is $@, "simulate exit\n";
+
+            $mock->verify;
+            $mock2->verify;
         };
     };
 };
 
 describe "minimal perl version" => sub {
     it "only executes the needed version" => sub {
-
         my @perl_paths;
         my $app = App::perlbrew->new(qw(exec --min 5.014), qw(perl -E), "say 42");
-        $app->expects("do_system_with_exit_code")->exactly(2)->returns(sub {
+
+        my $mock = mocked($app)->expects("do_system_with_exit_code")->exactly(2)->returns(sub {
             my ($self, @args) = @_;
             my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
             push @perl_paths, $perlbrew_perl_bin_path;
@@ -280,19 +384,21 @@ describe "minimal perl version" => sub {
         $app->run;
 
         # Don't care about the order, just the fact all of them were visited
-        is_deeply [sort @perl_paths], [sort (
-            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.2", "bin"),
-            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin"),
+        is [sort @perl_paths], [sort (
+            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.2", "bin")->stringify(),
+            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.14.1", "bin")->stringify(),
         )];
+
+        $mock->verify;
     };
 };
 
 describe "maximum perl version" => sub {
     it "only executes the needed version" => sub {
-
         my @perl_paths;
         my $app = App::perlbrew->new(qw(exec --max 5.014), qw(perl -E), "say 42");
-        $app->expects("do_system_with_exit_code")->exactly(2)->returns(sub {
+
+        my $mock = mocked($app)->expects("do_system_with_exit_code")->exactly(2)->returns(sub {
             my ($self, @args) = @_;
             my ($perlbrew_bin_path, $perlbrew_perl_bin_path, @paths) = split(":", $ENV{PATH});
             push @perl_paths, $perlbrew_perl_bin_path;
@@ -302,12 +408,13 @@ describe "maximum perl version" => sub {
         $app->run;
 
         # Don't care about the order, just the fact all of them were visited
-        is_deeply [sort @perl_paths], [sort (
-            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.4", "bin"),
-            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.3", "bin"),
+        is [sort @perl_paths], [sort (
+            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.4", "bin")->stringify(),
+            App::Perlbrew::Path->new($App::perlbrew::PERLBREW_ROOT, "perls", "perl-5.12.3", "bin")->stringify(),
         )];
+
+        $mock->verify;
     };
 };
 
-
-runtests unless caller;
+done_testing;

--- a/t/command-info.t
+++ b/t/command-info.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
-use Test::Spec;
+use Test2::V0;
+use Test2::Tools::Spec;
 use Test::Output;
 use File::Spec;
 use Config;
@@ -14,12 +13,15 @@ describe "info command" => sub {
 
         my $mock_perl = { mock => 'current_perl' };
         my $perl_path = $Config{perlpath};
+        my $mock = mock $app,
+            override => [
+                current_perl => sub { $mock_perl },
+                current_env => sub { 'perl-5.8.9' },
+                installed_perl_executable => sub { $perl_path },
+                configure_args => sub { 'config_args_value' },
+                system_perl_shebang => sub { die }
+            ];
 
-        $app->expects("current_perl")->returns($mock_perl)->at_least_once();
-        $app->expects("current_env")->returns('perl-5.8.9');
-        $app->expects("installed_perl_executable")->with($mock_perl)->returns($perl_path)->at_least_once();
-        $app->expects("configure_args")->with($mock_perl)->returns('config_args_value');
-        $app->expects("system_perl_shebang")->never;
         local $ENV{PERLBREW_ROOT} = 'perlbrew_root_value';
         local $ENV{PERLBREW_HOME} = 'perlbrew_home_value';
         local $ENV{PERLBREW_PATH} = 'perlbrew_path_value';
@@ -48,11 +50,15 @@ OUT
     it "should display info if under system perl" => sub {
         my $app = App::perlbrew->new("info");
 
-        $app->expects("current_perl")->returns('');
-        $app->expects("current_env")->never;
-        $app->expects("installed_perl_executable")->never;
-        $app->expects("configure_args")->never;
-        $app->expects("system_perl_shebang")->returns("system_perl_shebang_value")->once;
+        my $mock = mock $app,
+            override => [
+                current_perl => sub { '' },
+                current_env => sub { die },
+                installed_perl_executable => sub { die },
+                configure_args => sub { die },
+                system_perl_shebang => sub { "system_perl_shebang_value" },
+            ];
+
         local $ENV{PERLBREW_ROOT} = 'perlbrew_root_value';
         local $ENV{PERLBREW_HOME} = 'perlbrew_home_value';
         local $ENV{PERLBREW_PATH} = 'perlbrew_path_value';
@@ -84,11 +90,15 @@ OUT
         my $perl_path = $Config{perlpath};
         my $module_name = "Data::Dumper";
 
-        $app->expects("current_perl")->returns($mock_perl)->at_least_once();
-        $app->expects("current_env")->returns('perl-5.8.9');
-        $app->expects("installed_perl_executable")->with($mock_perl)->returns($perl_path)->at_least_once();
-        $app->expects("configure_args")->with($mock_perl)->returns('config_args_value');
-        $app->expects("system_perl_shebang")->never;
+        my $mock = mock $app,
+            override => [
+                "current_perl" => sub { $mock_perl },
+                "current_env" => sub { 'perl-5.8.9'},
+                "installed_perl_executable" => sub { $perl_path },
+                "configure_args" => sub { 'config_args_value' },
+                "system_perl_shebang" => sub { die },
+            ];
+
         local $ENV{PERLBREW_ROOT} = 'perlbrew_root_value';
         local $ENV{PERLBREW_HOME} = 'perlbrew_home_value';
         local $ENV{PERLBREW_PATH} = 'perlbrew_path_value';
@@ -131,11 +141,15 @@ OUT
         my $perl_path = $Config{perlpath};
         my $module_name = "SOME_FAKE_MODULE";
 
-        $app->expects("current_perl")->returns($mock_perl)->at_least_once();
-        $app->expects("current_env")->returns('perl-5.8.9');
-        $app->expects("installed_perl_executable")->with($mock_perl)->returns($perl_path)->at_least_once();
-        $app->expects("configure_args")->with($mock_perl)->returns('config_args_value');
-        $app->expects("system_perl_shebang")->never;
+        my $mock = mock $app,
+            override => [
+                "current_perl" => sub { $mock_perl },
+                "current_env" => sub { 'perl-5.8.9' },
+                "installed_perl_executable" => sub { $perl_path },
+                "configure_args" => sub { 'config_args_value' },
+                "system_perl_shebang" => sub { die },
+            ];
+
         local $ENV{PERLBREW_ROOT} = 'perlbrew_root_value';
         local $ENV{PERLBREW_HOME} = 'perlbrew_home_value';
         local $ENV{PERLBREW_PATH} = 'perlbrew_path_value';
@@ -167,5 +181,4 @@ OUT
 
 };
 
-
-runtests unless caller;
+done_testing;

--- a/t/command-install-cpanm.t
+++ b/t/command-install-cpanm.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
-use Test::Spec;
+use Test2::V0;
+use Test2::Tools::Spec;
 use File::Temp qw( tempdir );
 
 use App::perlbrew;
@@ -28,4 +27,4 @@ describe "App::perlbrew->install_cpanm" => sub {
     };
 };
 
-runtests unless caller;
+done_testing;

--- a/t/current_perl.t
+++ b/t/current_perl.t
@@ -1,12 +1,11 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
+use Test2::V0;
+use Test2::Tools::Spec;
+use App::perlbrew;
+
 use FindBin;
 use lib $FindBin::Bin;
-use App::perlbrew;
-require 'test_helpers.pl';
-
-use Test::Spec;
+require 'test2_helpers.pl';
 
 mock_perlbrew_install("perl-5.12.3");
 mock_perlbrew_install("perl-5.12.4");
@@ -45,5 +44,4 @@ describe "current perl" => sub {
     };
 };
 
-runtests unless caller;
-
+done_testing;

--- a/t/failure-command-install-patchperl.t
+++ b/t/failure-command-install-patchperl.t
@@ -1,7 +1,6 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
-use Test::Spec;
+use Test2::V0;
+use Test2::Tools::Spec;
 use Path::Class;
 use File::Temp qw( tempdir );
 
@@ -37,4 +36,4 @@ describe "App::perlbrew->install_patchperl" => sub {
     };
 };
 
-runtests unless caller;
+done_testing;

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -114,7 +114,7 @@ sub mocked {
     }
 }
 
-package Mocked {
+package Mocked; {
     use Test2::Tools::Mock qw(mock);
 
     sub new {
@@ -159,7 +159,7 @@ package Mocked {
     }
 }
 
-package MockedMethod {
+package MockedMethod; {
     use Test2::Tools::Basic qw(ok note);
     use Test2::Tools::Compare qw(is);
     use Test2::Tools::Mock qw(mock);

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -126,6 +126,18 @@ package Mocked {
         }, $class
     }
 
+    sub stubs {
+        my ($self, $stubs) = @_;
+        for my $k (keys %$stubs) {
+            my $v = $stubs->{$k};
+            if (ref($v) eq 'CODE') {
+                $self->{mock}->override($k => $v);
+            } else {
+                $self->{mock}->override($k => sub { $v });
+            }
+        }
+    }
+
     sub expects {
         my ($self, $method) = @_;
         my $mockedMethod = MockedMethod->new($self, $method);
@@ -139,10 +151,16 @@ package Mocked {
             $_->verify();
         }
     }
+
+    sub reset {
+        my ($self) = @_;
+        $self->{mock}->reset_all;
+        $self->{methods} = [];
+    }
 }
 
 package MockedMethod {
-    use Test2::Tools::Basic qw(ok);
+    use Test2::Tools::Basic qw(ok note);
     use Test2::Tools::Compare qw(is);
     use Test2::Tools::Mock qw(mock);
 

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -201,7 +201,7 @@ package MockedMethod {
                 $object->$method(@_);
             } else {
                 my $cb_or_value = $self->{returns};
-                (ref($cb_or_value) eq 'CODE') ? $cb_or_value->(@_) : $cb_or_value;
+                (ref($cb_or_value) eq 'CODE') ? $cb_or_value->($object, @_) : $cb_or_value;
             }
         }
     }

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -150,6 +150,7 @@ package MockedMethod {
         my ($class, $mocked, $method) = @_;
         return bless {
             called => 0,
+            at_least => undef,
             exactly => undef,
             method => $method,
             returns => undef,
@@ -168,9 +169,18 @@ package MockedMethod {
         unless ( defined $times ) {
             die "`exactly` requires a numerical argument.";
         }
-
         $self->{exactly} = $times;
+        $self->{at_least} = undef;
+        return $self;
+    }
 
+    sub at_least {
+        my ($self, $times) = @_;
+        unless ( defined $times ) {
+            die "`exactly` requires a numerical argument.";
+        }
+        $self->{exactly} = undef;
+        $self->{at_least} = $times;
         return $self;
     }
 
@@ -195,6 +205,9 @@ package MockedMethod {
         my ($self) = @_;
         if (defined $self->{exactly}) {
             is $self->{called}, $self->{exactly}, $self->{method} . " should be called exactly " . $self->{exactly} . " times";
+        }
+        elsif (defined $self->{at_least}) {
+            ok $self->{called} > $self->{at_least}, $self->{method} . " is called at least " .  $self->{at_least} . " time";
         }
         else {
             ok $self->{called} > 0, $self->{method} . " is called at least 1 time";

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -100,7 +100,7 @@ sub mock_perlbrew_lib_create {
     App::Perlbrew::Path->new($App::perlbrew::PERLBREW_HOME, "libs", $name)->mkpath;
 }
 
-# Some wrappers around Test2::Tools::Mock, to make transition easer from Test::Spec
+# Wrappers around Test2::Tools::Mock, a replacement of Test::Spec, more or less.
 
 sub mocked {
     my ($object, $cb) = @_;

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -160,7 +160,7 @@ package MockedMethod {
 
     sub never {
         my ($self) = @_;
-        $self->{exactly} = 0;
+        $self->exactly(0);
         return $self;
     }
 


### PR DESCRIPTION
`Test2::Tools::Spec` provides most of the features implemented in `Test::Spec` and is nearly a drop-in replacement.

Uses of methods from `Test::Spec::Mocks` needs to be reworked, namely when `expects` are being used.
