### PR TITLE
Remove IO::All from the list of test dependencies

### DIFF
--- a/META.json
+++ b/META.json
@@ -41,7 +41,6 @@
       "test" : {
          "requires" : {
             "File::Which" : "1.21",
-            "IO::All" : "0.51",
             "Path::Class" : "0.33",
             "Test2::Plugin::IOEvents" : "0.001001",
             "Test2::Plugin::NoWarnings" : "0.10",

--- a/META.yml
+++ b/META.yml
@@ -4,7 +4,6 @@ author:
   - 'Kang-min Liu  C<< <gugod@gugod.org> >>'
 build_requires:
   File::Which: '1.21'
-  IO::All: '0.51'
   Path::Class: '0.33'
   Test2::Plugin::IOEvents: '0.001001'
   Test2::Plugin::NoWarnings: '0.10'

--- a/cpanfile
+++ b/cpanfile
@@ -13,7 +13,6 @@ requires 'ExtUtils::MakeMaker'  => '7.22';
 on test => sub {
     requires 'File::Temp'           => '0.2304';
     requires 'File::Which'          => '1.21';
-    requires 'IO::All'              => '0.51';
     requires 'Path::Class'          => '0.33';
     requires 'Test2::V0'            => '0.000163';
     requires 'Test2::Plugin::NoWarnings' => '0.10';

--- a/t/12.destdir.t
+++ b/t/12.destdir.t
@@ -1,9 +1,12 @@
 #!perl
 use Test2::V0;
 use Capture::Tiny qw/capture/;
-use IO::All;
 use App::perlbrew;
 use File::Temp qw( tempdir );
+
+use FindBin;
+use lib $FindBin::Bin;
+use PerlbrewTestHelpers qw( write_file );
 
 $App::perlbrew::PERLBREW_ROOT = tempdir( CLEANUP => 1 );
 $App::perlbrew::PERLBREW_HOME = tempdir( CLEANUP => 1 );
@@ -47,7 +50,8 @@ sub App::perlbrew::do_install_release {
     $root->child("perls", $name, "bin")->mkpath;
 
     my $perl = $root->child("perls", $name, "bin")->child("perl");
-    io($perl)->print("#!/bin/sh\nperl \"\$@\";\n");
+
+    write_file($perl, "#!/bin/sh\nperl \"\$@\";\n");
     chmod 0755, $perl;
 
     # fake the install

--- a/t/12.sitecustomize.t
+++ b/t/12.sitecustomize.t
@@ -1,9 +1,12 @@
 #!perl
 use Test2::V0;
 use Capture::Tiny qw/capture/;
-use IO::All;
-use App::perlbrew;
 use File::Temp qw( tempdir );
+
+use FindBin;
+use lib $FindBin::Bin;
+use App::perlbrew;
+use PerlbrewTestHelpers qw(write_file);
 
 $App::perlbrew::PERLBREW_ROOT = tempdir( CLEANUP => 1 );
 $App::perlbrew::PERLBREW_HOME = tempdir( CLEANUP => 1 );
@@ -44,7 +47,7 @@ sub App::perlbrew::do_install_release {
     $root->child("perls", $name, "bin")->mkpath;
 
     my $perl = $root->child("perls", $name, "bin")->child("perl");
-    io($perl)->print("#!/bin/sh\nperl \"\$@\";\n");
+    write_file($perl, "#!/bin/sh\nperl \"\$@\";\n");
     chmod 0755, $perl;
 
     # fake the install

--- a/t/PerlbrewTestHelpers.pm
+++ b/t/PerlbrewTestHelpers.pm
@@ -58,11 +58,10 @@ sub read_file {
 }
 
 sub write_file {
-    my ($file) = @_;
+    my ($file, $content) = @_;
     open my $fh, '>', $file
         or die "Cannot open $file for write: $!";
-    local $/ = undef;
-    print $fh $file;
+    print $fh $content;
     close $fh;
     return;
 }

--- a/t/PerlbrewTestHelpers.pm
+++ b/t/PerlbrewTestHelpers.pm
@@ -3,7 +3,11 @@ use Test2::V0;
 use Test2::Plugin::IOEvents;
 
 use Exporter 'import';
-our @EXPORT_OK = qw(stderr_from stderr_is stderr_like stdout_from stdout_is stdout_like);
+our @EXPORT_OK = qw(
+    read_file write_file
+    stderr_from stderr_is stderr_like
+    stdout_from stdout_is stdout_like
+);
 
 # Replacements of Test::Output made by using Test2::Plugin::IOEvents
 
@@ -44,5 +48,23 @@ sub stdout_like (&$;$) {
     like(stdout_from(sub { $cb->() }), $re, $desc);
 }
 
+sub read_file {
+    my ($file) = @_;
+    open my $fh, '<', $file
+        or die "Cannot open $file for read: $!";
+    local $/ = undef;
+    my $content = <$fh>;
+    return $content;
+}
+
+sub write_file {
+    my ($file) = @_;
+    open my $fh, '>', $file
+        or die "Cannot open $file for write: $!";
+    local $/ = undef;
+    print $fh $file;
+    close $fh;
+    return;
+}
 
 1;

--- a/t/command-make-shim.t
+++ b/t/command-make-shim.t
@@ -8,6 +8,7 @@ use lib $FindBin::Bin;
 
 use App::perlbrew;
 require "test2_helpers.pl";
+use PerlbrewTestHelpers qw(read_file write_file);
 
 mock_perlbrew_install("perl-5.36.1");
 
@@ -51,7 +52,7 @@ describe "App::perlbrew->make_shim('foo')" => sub {
         mock_perlbrew_use("perl-5.36.1");
         my $dir = tempdir();
         chdir($dir);
-        io("foo")->print("hello");
+        write_file ("foo", "hello");
 
         ok dies {
             my $app = App::perlbrew->new("make-shim", "foo");
@@ -73,7 +74,7 @@ describe "App::perlbrew->make_shim('foo')" => sub {
         $app->run();
 
         ok -f "foo", "foo is produced under current directory.";
-        my $shim_content = io("foo")->slurp;
+        my $shim_content = read_file("foo");
         diag "\nThe content of shim:\n----\n$shim_content\n----\n";
     };
 
@@ -86,7 +87,7 @@ describe "App::perlbrew->make_shim('foo')" => sub {
         $app->run();
 
         ok -f "foo", "foo is produced under current directory.";
-        my $shim_content = io("foo")->slurp;
+        my $shim_content = read_file("foo");
         diag "\nThe content of shim:\n----\n$shim_content\n----\n";
     };
 };

--- a/t/error-http_download-param-validation.t
+++ b/t/error-http_download-param-validation.t
@@ -1,14 +1,18 @@
 #!/usr/bin/env perl
 use Test2::V0;
 use File::Temp qw(tempdir);
-use IO::All;
+
+use FindBin;
+use lib $FindBin::Bin;
+use PerlbrewTestHelpers qw(write_file);
+
 use App::Perlbrew::HTTP qw(http_download);
 
 subtest "http_download: dies when when the download target already exists" => sub {
     my $dir    = tempdir( CLEANUP => 1 );
     my $output = "$dir/whatever";
 
-    io($output)->print("so");
+    write_file($output, "so");
 
     my $error;
     like(

--- a/t/http.t
+++ b/t/http.t
@@ -1,14 +1,17 @@
 #!/usr/bin/env perl
 use Test2::V0;
 use Test2::Tools::Spec;
-use App::perlbrew;
 use File::Temp 'tempdir';
-use IO::All;
 
+use App::perlbrew;
 use App::Perlbrew::HTTP qw(http_user_agent_program http_get http_download);
 
+use FindBin;
+use lib $FindBin::Bin;
+use PerlbrewTestHelpers qw( read_file );
+
 unless ($ENV{PERLBREW_DEV_TEST}) {
-    skip_all => <<REASON;
+    skip_all <<REASON;
 
 This test invokes HTTP request to external servers and should not be ran in
 blind. Whoever which to test this need to set PERLBREW_DEV_TEST env var to 1.
@@ -65,7 +68,9 @@ REASON
     };
 
     it "seems to be downloading the right content" => sub {
-        is(scalar(io($output)->getline), "#!/bin/sh\n");
+        my $content = read_file($output);
+        my ($first_line, undef) = split /\n/, $content, 2;
+        is ($first_line, "#!/bin/sh");
     };
 };
 

--- a/t/test2_helpers.pl
+++ b/t/test2_helpers.pl
@@ -16,11 +16,12 @@ put 't/' dir to `@INC`.
 
 use Test2::V0;
 use Test2::Plugin::IOEvents;
-use IO::All;
 use File::Temp qw( tempdir );
 
 use App::Perlbrew::Path;
 use App::Perlbrew::Path::Root;
+
+use PerlbrewTestHelpers qw(write_file);
 
 no warnings 'redefine';
 sub dir {
@@ -62,7 +63,7 @@ sub App::perlbrew::do_install_release {
     $root->perls($name, "bin")->mkpath;
 
     my $perl = $root->perls ($name, "bin")->child ("perl");
-    io($perl)->print(<<'CODE');
+    write_file($perl, <<'CODE');
 #!/usr/bin/env perl
 use File::Basename;
 my $name = basename(dirname(dirname($0))), "\n";


### PR DESCRIPTION
I'm not sure if this small changes can be counted as an "improvement", but we've only use 2 very basic feature from `IO::All` and it can be easily replaced by some naive version of `read_file` and `write_file` that reads/writes entire file at once.

I guess getting rid of all the indirect dependencies can be counted as improvements.