### PR TITLE
make `install` accept skaji-relocatable by name.

### DIFF
--- a/lib/App/Perlbrew/Util.pm
+++ b/lib/App/Perlbrew/Util.pm
@@ -5,7 +5,12 @@ use 5.008;
 
 use Exporter 'import';
 our @EXPORT = qw( uniq min editdist files_are_the_same perl_version_to_integer );
-our @EXPORT_OK = qw( find_similar_tokens looks_like_url_of_skaji_relocatable_perl looks_like_sys_would_be_compatible_with_skaji_relocatable_perl );
+our @EXPORT_OK = qw(
+    find_similar_tokens
+    looks_like_url_of_skaji_relocatable_perl
+    looks_like_sys_would_be_compatible_with_skaji_relocatable_perl
+    make_skaji_relocatable_perl_url
+);
 
 sub uniq {
     my %seen;
@@ -130,6 +135,19 @@ sub looks_like_sys_would_be_compatible_with_skaji_relocatable_perl {
         ($detail->{os} eq $sys->os)
         && (_arch_compat($detail->{arch}) eq _arch_compat($sys->arch))
     );
+}
+
+sub make_skaji_relocatable_perl_url {
+    my ($str, $sys) = @_;
+    if ($str =~ m/\Askaji-relocatable-perl-(5\.[0-9][0-9]\.[0-9][0-9]?.[0-9])\z/) {
+        my $version = $1;
+        my $os = $sys->os;
+        my $arch = $sys->arch;
+        $arch = "amd64" if $arch eq 'x86_64';
+
+        return "https://github.com/skaji/relocatable-perl/releases/download/$version/perl-$os-$arch.tar.gz";
+    }
+    return undef;
 }
 
 1;

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -24,7 +24,7 @@ use JSON::PP qw( decode_json );
 use File::Copy qw( copy move );
 use Capture::Tiny ();
 
-use App::Perlbrew::Util qw( files_are_the_same uniq find_similar_tokens looks_like_url_of_skaji_relocatable_perl looks_like_sys_would_be_compatible_with_skaji_relocatable_perl);
+use App::Perlbrew::Util qw( files_are_the_same uniq find_similar_tokens looks_like_url_of_skaji_relocatable_perl looks_like_sys_would_be_compatible_with_skaji_relocatable_perl make_skaji_relocatable_perl_url );
 use App::Perlbrew::Path ();
 use App::Perlbrew::Path::Root ();
 use App::Perlbrew::HTTP qw( http_download http_get );
@@ -1228,6 +1228,10 @@ sub run_command_install {
     unless ($dist) {
         $self->run_command_help("install");
         exit(-1);
+    }
+
+    if ( my $url = make_skaji_relocatable_perl_url($dist, $self->sys) ) {
+        return $self->run_command_install($url);
     }
 
     if ( my $detail = looks_like_url_of_skaji_relocatable_perl($dist) ) {


### PR DESCRIPTION
The "name" is in the form of

    skaji-relocatable-perl-$version

The name is only used to make the URL of the tarball.