### PR TITLE
`arch` needs to be derived from myarchname.

### DIFF
--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -16,7 +16,7 @@ sub os {
 }
 
 sub arch {
-    (split(/-/, $Config{archname}, 2))[0]
+    (split(/-/, $Config{myarchname}, 2))[0]
 }
 
 1;


### PR DESCRIPTION
On macOS, `archname` do not contain arch like the way it is on linux:

    # perl -V:archname
    archname='darwin-2level';

But myarchname does:

    # perl -V:myarchname
    myarchname='arm64-darwin';