### PR TITLE
map i386 to x86_64 when making urls of skaji-relocatable-perl

### DIFF
--- a/lib/App/Perlbrew/Util.pm
+++ b/lib/App/Perlbrew/Util.pm
@@ -123,7 +123,8 @@ sub looks_like_url_of_skaji_relocatable_perl  {
 sub _arch_compat {
     my ($arch) = @_;
     my $compat = {
-        x86_64 => "amd64"
+        x86_64 => "amd64",
+        i386   => "amd64",
     };
     return $compat->{$arch} || $arch;
 }

--- a/lib/App/Perlbrew/Util.pm
+++ b/lib/App/Perlbrew/Util.pm
@@ -143,7 +143,7 @@ sub make_skaji_relocatable_perl_url {
         my $version = $1;
         my $os = $sys->os;
         my $arch = $sys->arch;
-        $arch = "amd64" if $arch eq 'x86_64';
+        $arch = "amd64" if $arch eq 'x86_64' || $arch eq 'i386';
 
         return "https://github.com/skaji/relocatable-perl/releases/download/$version/perl-$os-$arch.tar.gz";
     }

--- a/perlbrew
+++ b/perlbrew
@@ -560,7 +560,7 @@ $fatpacked{"App/Perlbrew/Util.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".
           my $version = $1;
           my $os = $sys->os;
           my $arch = $sys->arch;
-          $arch = "amd64" if $arch eq 'x86_64';
+          $arch = "amd64" if $arch eq 'x86_64' || $arch eq 'i386';
   
           return "https://github.com/skaji/relocatable-perl/releases/download/$version/perl-$os-$arch.tar.gz";
       }

--- a/perlbrew
+++ b/perlbrew
@@ -540,7 +540,8 @@ $fatpacked{"App/Perlbrew/Util.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".
   sub _arch_compat {
       my ($arch) = @_;
       my $compat = {
-          x86_64 => "amd64"
+          x86_64 => "amd64",
+          i386   => "amd64",
       };
       return $compat->{$arch} || $arch;
   }


### PR DESCRIPTION
Since they do not provide build in i386 and nowadays 64bit arch is probably more popular, this seems reasonable.