### PR TITLE
App::perlbrew->run_command_exec: getopt nopass_through

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2313,7 +2313,7 @@ sub run_command_exec {
 
     local (@ARGV) = @{ $self->{original_argv} };
 
-    Getopt::Long::Configure('require_order');
+    Getopt::Long::Configure( 'require_order', 'nopass_through' );
     my @command_options = ( 'with=s', 'halt-on-error', 'min=s', 'max=s' );
 
     $self->parse_cmdline( \%opts, @command_options );


### PR DESCRIPTION
reconfiguring configured "permute" (with "require_order") is not enough to DWIM, configured "pass_through" must be overriden too.

DWIM:
1) to allow "--" to work
   e.g. perlbrew exec -- perl -E 'say $]'
   does what README states, not
     Can't exec "--": No such file or directory
2) allow commands to run as expected
   e.g. perlbrew exec -- prog --version
     runs "prog --version", not "perlbrew --version"