### PR TITLE
Shorter commands

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+NEXT
+	- `uninstall` command now has shorter names: `rm` and `delete`.
+
 1.01
 	- Released at 2024-11-18T20:46:04+0900
 	- fix: `perlbrew install skaji-relocatable-perl-$version` on macOS.

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -511,6 +511,10 @@ sub run_command_help {
             my $out = "";
             open my $fh, ">", \$out;
 
+            if (my $x = resolve_command_alias($command)) {
+                $command = $x;
+            }
+
             Pod::Usage::pod2usage(
                 -exitval   => "NOEXIT",
                 -verbose   => 99,

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -499,13 +499,13 @@ sub run_command_version {
 # documentation via the POD of the class itself using the
 # section 'COMMAND: $x' with uppercase $x.
 sub run_command_help {
-    my ( $self, $status, $verbose, $return_text ) = @_;
+    my ( $self, $command, $verbose, $return_text ) = @_;
 
     require Pod::Usage;
 
-    if ( $status && !defined($verbose) ) {
-        if ( $self->can("run_command_help_${status}") ) {
-            $self->can("run_command_help_${status}")->($self);
+    if ( $command && !defined($verbose) ) {
+        if ( $self->can("run_command_help_$command") ) {
+            $self->can("run_command_help_$command")->($self);
         }
         else {
             my $out = "";
@@ -514,7 +514,7 @@ sub run_command_help {
             Pod::Usage::pod2usage(
                 -exitval   => "NOEXIT",
                 -verbose   => 99,
-                -sections  => "COMMAND: " . uc($status),
+                -sections  => "COMMAND: " . uc($command),
                 -output    => $fh,
                 -noperldoc => 1
             );
@@ -522,7 +522,7 @@ sub run_command_help {
             $out =~ s/^    //gm;
 
             if ( $out =~ /\A\s*\Z/ ) {
-                $out = "Cannot find documentation for '$status'\n\n";
+                $out = "Cannot find documentation for '$command'\n\n";
             }
 
             return "\n$out" if ($return_text);
@@ -534,7 +534,7 @@ sub run_command_help {
         Pod::Usage::pod2usage(
             -noperldoc => 1,
             -verbose   => $verbose || 0,
-            -exitval   => ( defined $status ? $status : 1 )
+            -exitval   => ( defined $command ? $command : 1 )
         );
     }
 }

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -103,6 +103,16 @@ for (@flavors) {
     }
 }
 
+my %command_aliases = (
+    'rm' => 'uninstall',
+    'delete' => 'uninstall',
+);
+
+sub resolve_command_alias {
+    my $x = shift;
+    $command_aliases{$x};
+}
+
 ### methods
 sub new {
     my ( $class, @argv ) = @_;
@@ -449,6 +459,12 @@ sub run_command {
     unless ($s) {
         $x =~ y/-/_/;
         $s = $self->can("run_command_$x");
+    }
+
+    unless ($s) {
+        if (my $x = resolve_command_alias($x)) {
+            $s = $self->can("run_command_$x")
+        }
     }
 
     unless ($s) {

--- a/script/perlbrew
+++ b/script/perlbrew
@@ -296,7 +296,14 @@ Another example using custom compilation flags:
 
 =head1 COMMAND: UNINSTALL
 
-Usage: perlbrew uninstall <name>
+Usage:
+
+    perlbrew uninstall <name>
+
+Alternatively:
+
+    perlbrew delete <name>
+    perlbrew rm <name>
 
 Uninstalls the given perl installation. The name is the installation name as in
 the output of `perlbrew list`. This effectively deletes the specified perl installation,


### PR DESCRIPTION
- Let` `rm` and `delete`  be aliases of `uninstall`.
- Let `help rm` and `help delete` show the help message of `uninstall`.
- Mention `rm` and `delete` in the help message.
