### PR TITLE
On cygwin, require `--force-local -` parameter to `tar`.

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1139,14 +1139,26 @@ sub do_extract_tarball {
     $workdir->mkpath;
     my $extracted_dir;
 
-    # Was broken on Solaris, where GNU tar is probably
-    # installed as 'gtar' - RT #61042
-    my $tarx = ( $^O =~ /solaris|aix/ ? 'gtar ' : 'tar ' )
-        . (
-          $dist_tarball =~ m/xz$/  ? 'xJf'
-        : $dist_tarball =~ m/bz2$/ ? 'xjf'
-        :                            'xzf'
-        );
+    my $tarx;
+    if ($^O eq 'cygwin') {
+        # https://github.com/gugod/App-perlbrew/issues/832
+        # https://github.com/gugod/App-perlbrew/issues/833
+        $tarx = 'tar --force-local -';
+    } elsif ($^O =~ /solaris|aix/) {
+        # On Solaris, GNU tar is installed as 'gtar' - RT #61042
+        # https://rt.cpan.org/Ticket/Display.html?id=61042
+        $tarx = 'gtar ';
+    } else {
+        $tarx = 'tar ';
+    }
+
+    if ($dist_tarball =~ m/xz$/) {
+        $tarx .= 'xJf';
+    } elsif ($dist_tarball =~ m/bz2$/) {
+        $tarx .= 'xjf';
+    } else {
+        $tarx .= 'xzf';
+    }
 
     my $extract_command = "cd $workdir; $tarx $dist_tarball";
     die "Failed to extract $dist_tarball" if system($extract_command);

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1139,26 +1139,29 @@ sub do_extract_tarball {
     $workdir->mkpath;
     my $extracted_dir;
 
-    my $tarx;
-    if ($^O eq 'cygwin') {
-        # https://github.com/gugod/App-perlbrew/issues/832
-        # https://github.com/gugod/App-perlbrew/issues/833
-        $tarx = 'tar --force-local -';
-    } elsif ($^O =~ /solaris|aix/) {
-        # On Solaris, GNU tar is installed as 'gtar' - RT #61042
-        # https://rt.cpan.org/Ticket/Display.html?id=61042
-        $tarx = 'gtar ';
-    } else {
-        $tarx = 'tar ';
-    }
+    my $tarx = do {
+        if ($^O eq 'cygwin') {
+            # https://github.com/gugod/App-perlbrew/issues/832
+            # https://github.com/gugod/App-perlbrew/issues/833
+            'tar --force-local - '
+        } elsif ($^O =~ /solaris|aix/) {
+            # On Solaris, GNU tar is installed as 'gtar' - RT #61042
+            # https://rt.cpan.org/Ticket/Display.html?id=61042
+            'gtar '
+        } else {
+            'tar '
+        }
+    };
 
-    if ($dist_tarball =~ m/xz$/) {
-        $tarx .= 'xJf';
-    } elsif ($dist_tarball =~ m/bz2$/) {
-        $tarx .= 'xjf';
-    } else {
-        $tarx .= 'xzf';
-    }
+    $tarx .= do {
+        if ($dist_tarball =~ m/xz$/) {
+            'xJf'
+        } elsif ($dist_tarball =~ m/bz2$/) {
+            'xjf'
+        } else {
+            'xzf'
+        }
+    };
 
     my $extract_command = "cd $workdir; $tarx $dist_tarball";
     die "Failed to extract $dist_tarball" if system($extract_command);

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1143,7 +1143,7 @@ sub do_extract_tarball {
         if ($^O eq 'cygwin') {
             # https://github.com/gugod/App-perlbrew/issues/832
             # https://github.com/gugod/App-perlbrew/issues/833
-            'tar --force-local - '
+            'tar --force-local -'
         } elsif ($^O =~ /solaris|aix/) {
             # On Solaris, GNU tar is installed as 'gtar' - RT #61042
             # https://rt.cpan.org/Ticket/Display.html?id=61042


### PR DESCRIPTION
Originally: #833 , #832

From #832:

    The problem occurs where perlbrew acts on a downloaded perl
    archive, using gnu tar to expand it. Gnu tar must not be used on a
    filename that is absolute, on cygwin or MSWindows, because it
    misunderstands the C: as referring to a remote tape drive or
    similar device. The flag --force-local must be used or tar dies
    with an error.

While I would very much like to see someone setup their C:\ being a tape drive, that would have to be the topic for those retro-PC youtubers, no perlbrew.