### PR TITLE
Make patchperl optional

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 NEXT
 	- `uninstall` command now has shorter names: `rm` and `delete`.
+	- `patchperl` is now an optional dependency.
 
 1.01
 	- Released at 2024-11-18T20:46:04+0900

--- a/lib/App/Perlbrew/Patchperl.pm
+++ b/lib/App/Perlbrew/Patchperl.pm
@@ -1,0 +1,40 @@
+package App::Perlbrew::Patchperl;
+use strict;
+use warnings;
+use 5.008;
+
+use App::Perlbrew::Path::Root;
+
+use Exporter 'import';
+our @EXPORT_OK = qw(maybe_patchperl);
+
+sub maybe_patchperl {
+    my App::Perlbrew::Path::Root $perlbrew_root = shift;
+    return (
+        maybe_patchperl_in_app_root($perlbrew_root) ||
+        maybe_patchperl_in_system()
+    );
+}
+
+sub maybe_patchperl_in_app_root {
+    my App::Perlbrew::Path::Root $perlbrew_root = shift;
+    my $patchperl = $perlbrew_root->bin("patchperl");
+
+    if (-x $patchperl && -f _) {
+        return $patchperl;
+    } else {
+        return undef;
+    }
+}
+
+sub maybe_patchperl_in_system {
+    my $code = system("patchperl --version") >> 8;
+
+    if ($code != 127) {
+        return "patchperl"
+    } else {
+        return undef;
+    }
+}
+
+1;

--- a/lib/App/Perlbrew/Patchperl.pm
+++ b/lib/App/Perlbrew/Patchperl.pm
@@ -4,6 +4,7 @@ use warnings;
 use 5.008;
 
 use App::Perlbrew::Path::Root;
+use Capture::Tiny qw(capture);
 
 use Exporter 'import';
 our @EXPORT_OK = qw(maybe_patchperl);
@@ -28,9 +29,11 @@ sub maybe_patchperl_in_app_root {
 }
 
 sub maybe_patchperl_in_system {
-    my $code = system("patchperl --version");
+    my (undef, undef, $exit_status) = capture {
+        system("patchperl --version");
+    };
 
-    if ($code == 0) {
+    if ($exit_status == 0) {
         return "patchperl"
     } else {
         return undef;

--- a/lib/App/Perlbrew/Patchperl.pm
+++ b/lib/App/Perlbrew/Patchperl.pm
@@ -28,9 +28,9 @@ sub maybe_patchperl_in_app_root {
 }
 
 sub maybe_patchperl_in_system {
-    my $code = system("patchperl --version") >> 8;
+    my $code = system("patchperl --version");
 
-    if ($code != 127) {
+    if ($code == 0) {
         return "patchperl"
     } else {
         return undef;

--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -28,6 +28,7 @@ use App::Perlbrew::Util qw( files_are_the_same uniq find_similar_tokens looks_li
 use App::Perlbrew::Path ();
 use App::Perlbrew::Path::Root ();
 use App::Perlbrew::HTTP qw( http_download http_get );
+use App::Perlbrew::Patchperl qw( maybe_patchperl );
 use App::Perlbrew::Sys;
 
 ### global variables
@@ -1583,13 +1584,9 @@ INSTALL
 
     my @preconfigure_commands = ( "cd $dist_extracted_dir", "rm -f config.sh Policy.sh", );
 
-    unless ( $self->{"no-patchperl"} || $looks_like_we_are_installing_cperl ) {
-        my $patchperl = $self->root->bin("patchperl");
-
-        unless ( -x $patchperl && -f _ ) {
-            $patchperl = "patchperl";
-        }
-
+    if ((not $self->{"no-patchperl"})
+        && (not $looks_like_we_are_installing_cperl)
+        && (my $patchperl = maybe_patchperl($self->root))) {
         push @preconfigure_commands, 'chmod -R +w .', $patchperl;
     }
 

--- a/t/20.patchperl.t
+++ b/t/20.patchperl.t
@@ -65,6 +65,24 @@ describe "App::Perlbrew::Patchperl maybe_patchperl" => sub {
             is $patchperl, string $app_root->bin("patchperl");
         };
     };
+
+    describe "When patchperl exist in PERLBREW_ROOT but it is not an executable file", sub {
+        before_each "put a non-exutable file named patchperl under PERLBREW_ROOT" => sub {
+            my $app_root_bin = App::perlbrew->new->root->bin();
+            $app_root_bin->mkpath;
+            my $path = $app_root_bin->child("patchperl");
+            open my $fh, ">", $path
+                or die "Failed to open $path for writing";
+            print $fh, "dummy\n";
+            close $fh;
+        };
+
+        it "should return undef", sub {
+            my $app_root = App::perlbrew->new->root;
+            my $patchperl = maybe_patchperl( $app_root );
+            is $patchperl, U();
+        };
+    };
 };
 
 done_testing;

--- a/t/20.patchperl.t
+++ b/t/20.patchperl.t
@@ -1,0 +1,88 @@
+#!/usr/bin/env perl
+use Test2::V0;
+use Test2::Tools::Spec;
+
+use FindBin;
+use File::Temp qw(tempdir);
+
+use lib $FindBin::Bin;
+use App::perlbrew;
+use App::Perlbrew::Patchperl qw(maybe_patchperl);
+require "test2_helpers.pl";
+
+describe "App::Perlbrew::Patchperl maybe_patchperl" => sub {
+    local $App::perlbrew::PERLBREW_ROOT;
+    local $ENV{PATH};
+
+    before_each init => sub {
+        # Since patchperl may exist in developer's environment,
+        # we override PATH to make the probe fail not able to find patchperl.
+        $App::perlbrew::PERLBREW_ROOT = tempdir();
+        $ENV{PATH} = "/bin";
+    };
+
+    it "should return undef, when patchperl does not exist" => sub {
+        my $app_root = App::perlbrew->new->root;
+        my $patchperl = maybe_patchperl( $app_root );
+        is $patchperl, U();
+    };
+
+    describe "When patchperl exist in PATH", sub {
+        my $bin = tempdir();
+
+        before_each "fake-install a patchperl under PATH" => sub {
+            $ENV{PATH} = "/bin:$bin";
+            fake_install_patchperl("$bin/patchperl");
+        };
+
+        it "should return just 'patchperl', when patchperl do not exist in PERLBREW_ROOT" => sub {
+            my $app_root = App::perlbrew->new->root;
+            my $patchperl = maybe_patchperl( $app_root );
+            is $patchperl, string "patchperl";
+        };
+
+        describe "When patchperl also exists in PERLBREW_ROOT", sub {
+            before_each "fake-install a patchperl under PERLBREW_ROOT" => sub {
+                fake_install_patchperl_under_app_root();
+            };
+
+            it "should return the path of patchperl under app root", sub {
+                my $app_root = App::perlbrew->new->root;
+                my $patchperl = maybe_patchperl( $app_root );
+                is $patchperl, string $app_root->bin("patchperl");
+            };
+        };
+    };
+
+    describe "When patchperl exist in PERLBREW_ROOT but not in PATH", sub {
+        before_each "fake-install a patchperl under PERLBREW_ROOT" => sub {
+            fake_install_patchperl_under_app_root();
+        };
+
+        it "should return the path of patchperl under app root", sub {
+            my $app_root = App::perlbrew->new->root;
+            my $patchperl = maybe_patchperl( $app_root );
+            is $patchperl, string $app_root->bin("patchperl");
+        };
+    };
+};
+
+done_testing;
+
+sub fake_install_patchperl {
+    my ($path) = @_;
+
+    open my $fh, ">", $path
+        or die "Failed to fake-install a patchperl to $path";
+    print $fh, '#!/usr/bin/env perl\nperl "Fake patchperl version 1.00\n";';
+    close $fh;
+    chmod 0755, $path;
+
+    diag "Fake-install a patchperl to $path";
+}
+
+sub fake_install_patchperl_under_app_root {
+    my $app_root_bin = App::perlbrew->new->root->bin();
+    $app_root_bin->mkpath;
+    fake_install_patchperl( $app_root_bin->child("patchperl") );
+}


### PR DESCRIPTION
With this PR we make patchperl  optional. Meaning that `perlbrew install` should not be failing due to the absense of patchperl in the system.
