### PR TITLE
bashrc: guard $outsep and $PERLBREW_LIB under set -euo pipefail

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -2983,7 +2983,7 @@ __perlbrew_purify () {
         case "$path" in
             (*"$PERLBREW_HOME"*) ;;
             (*"$PERLBREW_ROOT"*) ;;
-            (*) printf '%s' "$outsep$path" ; outsep=: ;;
+            (*) printf '%s' "${outsep:-}$path" ; outsep=: ;;
         esac
     done
 }
@@ -3006,7 +3006,7 @@ __perlbrew_activate() {
     [[ -n $(alias perl 2>/dev/null) ]] && unalias perl 2>/dev/null
 
     if [[ -n "${PERLBREW_PERL:-}" ]]; then
-          __perlbrew_set_env "${PERLBREW_PERL:-}${PERLBREW_LIB:+@}$PERLBREW_LIB"
+          __perlbrew_set_env "${PERLBREW_PERL:-}${PERLBREW_LIB:+@}${PERLBREW_LIB:-}"
     fi
 
     __perlbrew_set_path
@@ -3035,7 +3035,7 @@ perlbrew () {
         (use)
             if [[ -z "$2" ]] ; then
                 echo -n "Currently using ${PERLBREW_PERL:-system perl}"
-                [ -n "$PERLBREW_LIB" ] && echo -n "@$PERLBREW_LIB"
+                [ -n "${PERLBREW_LIB:-}" ] && echo -n "@${PERLBREW_LIB:-}"
                 echo
             else
                 __perlbrew_set_env "$2" && { __perlbrew_set_path ; true ; }
@@ -3157,10 +3157,10 @@ function __perlbrew_activate
     functions -e perl
 
     if test -n "$PERLBREW_PERL"
-        if test -z "$PERLBREW_LIB"
+        if test -z "${PERLBREW_LIB:-}"
             __perlbrew_set_env $PERLBREW_PERL
         else
-            __perlbrew_set_env $PERLBREW_PERL@$PERLBREW_LIB
+            __perlbrew_set_env $PERLBREW_PERL@${PERLBREW_LIB:-}
         end
     end
 

--- a/perlbrew
+++ b/perlbrew
@@ -3525,7 +3525,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
           case "$path" in
               (*"$PERLBREW_HOME"*) ;;
               (*"$PERLBREW_ROOT"*) ;;
-              (*) printf '%s' "$outsep$path" ; outsep=: ;;
+              (*) printf '%s' "${outsep:-}$path" ; outsep=: ;;
           esac
       done
   }
@@ -3548,7 +3548,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
       [[ -n $(alias perl 2>/dev/null) ]] && unalias perl 2>/dev/null
   
       if [[ -n "${PERLBREW_PERL:-}" ]]; then
-            __perlbrew_set_env "${PERLBREW_PERL:-}${PERLBREW_LIB:+@}$PERLBREW_LIB"
+            __perlbrew_set_env "${PERLBREW_PERL:-}${PERLBREW_LIB:+@}${PERLBREW_LIB:-}"
       fi
   
       __perlbrew_set_path
@@ -3577,7 +3577,7 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
           (use)
               if [[ -z "$2" ]] ; then
                   echo -n "Currently using ${PERLBREW_PERL:-system perl}"
-                  [ -n "$PERLBREW_LIB" ] && echo -n "@$PERLBREW_LIB"
+                  [ -n "${PERLBREW_LIB:-}" ] && echo -n "@${PERLBREW_LIB:-}"
                   echo
               else
                   __perlbrew_set_env "$2" && { __perlbrew_set_path ; true ; }
@@ -3699,10 +3699,10 @@ $fatpacked{"App/perlbrew.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'AP
       functions -e perl
   
       if test -n "$PERLBREW_PERL"
-          if test -z "$PERLBREW_LIB"
+          if test -z "${PERLBREW_LIB:-}"
               __perlbrew_set_env $PERLBREW_PERL
           else
-              __perlbrew_set_env $PERLBREW_PERL@$PERLBREW_LIB
+              __perlbrew_set_env $PERLBREW_PERL@${PERLBREW_LIB:-}
           end
       end
   


### PR DESCRIPTION
Strict mode surfaced two separate nounset crashes.

1. First subshell dies early on $PERLBREW_LIB:

       bash -c 'set -euo pipefail; source "$PERLBREW_ROOT/etc/bashrc"'
       # line 45: PERLBREW_LIB: unbound variable
       # exit 1

2. After that expansion is guarded, the same command still fails on the next run, this time inside __perlbrew_purify where $outsep is used before it is initialized:

       # line 24: outsep: unbound variable
       # exit 1

Both sites are now wrapped in ${var:-}, so an unset variable expands to an empty string instead of aborting.  With the patch:

    bash -c 'set -euo pipefail; source "$PERLBREW_ROOT/etc/bashrc"'
    # exit 0

... and Perl 5.42.0 installs cleanly.

Patched both generators (lib/App/perlbrew.pm and perlbrew) so newly generated bashrc files inherit the fix.