### PR TITLE
Remove bash-isms from PERLBREW_FISH_CONTENT

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -3157,10 +3157,10 @@ function __perlbrew_activate
     functions -e perl
 
     if test -n "$PERLBREW_PERL"
-        if test -z "${PERLBREW_LIB:-}"
+        if test -z "$PERLBREW_LIB"
             __perlbrew_set_env $PERLBREW_PERL
         else
-            __perlbrew_set_env $PERLBREW_PERL@${PERLBREW_LIB:-}
+            __perlbrew_set_env $PERLBREW_PERL@$PERLBREW_LIB
         end
     end
 


### PR DESCRIPTION
Version 1.0.2 causes these errors to appear when the `fish` shell starts up and sources `perlbrew.fish`:

```
$ /opt/homebrew/bin/fish
~/perl5/perlbrew/etc/perlbrew.fish (line 49): ${ is not a valid variable in fish.
        if test -z "${PERLBREW_LIB:-}"
                     ^
from sourcing file ~/perl5/perlbrew/etc/perlbrew.fish
	called on line 8 of file ~/.config/fish/config.fish
from sourcing file ~/.config/fish/config.fish
	called during startup
source: Error while reading file '/path/to/home/perl5/perlbrew/etc/perlbrew.fish'
Welcome to fish, the friendly interactive shell
```

This was caused by commit e257ed0c which was targeting a bash issue only, but the change to use bash style defaulting `${VARNAME:-}` was made to `PERLBREW_FISH_CONTENT` too.

This commit/PR reverts just those specific changes.