### PR TITLE
choroe: Test `install-cpm` in e2e.

### DIFF
--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -81,15 +81,28 @@ test-perlbrew-available() {
 test-perlbrew-install-cpm() {
     assert-file-missing $PERLBREW_ROOT/bin/cpm
 
-    echo n | $PERLBREW install-cpm
-    assert-file-missing $PERLBREW_ROOT/bin/cpm
-
-    # Yes, specifically
-    echo y | $PERLBREW install-cpm
-    assert-file-exists $PERLBREW_ROOT/bin/cpm
-
-    # Default is "yes, but do not override."
-    rm $PERLBREW_ROOT/bin/cpm
+    echo '# Default is "yes, but do not override."'
     echo | $PERLBREW install-cpm
     assert-file-exists $PERLBREW_ROOT/bin/cpm
+
+    echo '# No, do not override'
+    echo "dummy" > $PERLBREW_ROOT/bin/cpm
+    echo n | $PERLBREW install-cpm
+    assert-file-exists $PERLBREW_ROOT/bin/cpm
+
+    if [[ `head -c 5 $PERLBREW_ROOT/bin/cpm` == "dummy" ]]; then
+        echo "OK - not overrided"
+    else
+        echo "FAIL - overrided"
+    fi
+
+    echo '# Yes, do override'
+    echo "dummy" > $PERLBREW_ROOT/bin/cpm
+    echo y | $PERLBREW install-cpm
+    assert-file-exists $PERLBREW_ROOT/bin/cpm
+    if [[ `head -c 5 $PERLBREW_ROOT/bin/cpm` == "dummy" ]]; then
+        echo "FAIL - not overrided"
+    else
+        echo "OK - overrided"
+    fi
 }

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -77,3 +77,18 @@ test-perlbrew-available() {
     assert-ok $PERLBREW available
     assert-ok "$PERLBREW available | grep 'perl-5.40.2'"
 }
+
+test-perlbrew-install-cpm() {
+    assert-file-missing $PERLBREW_ROOT/bin/cpm
+
+    echo n | $PERLBREW install-cpm
+    assert-file-missing $PERLBREW_ROOT/bin/cpm
+
+    # Default is "N"
+    echo | $PERLBREW install-cpm
+    assert-file-missing $PERLBREW_ROOT/bin/cpm
+
+    # Yes, specifically
+    echo y | $PERLBREW install-cpm
+    assert-file-exists $PERLBREW_ROOT/bin/cpm
+}

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -84,11 +84,12 @@ test-perlbrew-install-cpm() {
     echo n | $PERLBREW install-cpm
     assert-file-missing $PERLBREW_ROOT/bin/cpm
 
-    # Default is "N"
-    echo | $PERLBREW install-cpm
-    assert-file-missing $PERLBREW_ROOT/bin/cpm
-
     # Yes, specifically
     echo y | $PERLBREW install-cpm
+    assert-file-exists $PERLBREW_ROOT/bin/cpm
+
+    # Default is "yes, but do not override."
+    rm $PERLBREW_ROOT/bin/cpm
+    echo | $PERLBREW install-cpm
     assert-file-exists $PERLBREW_ROOT/bin/cpm
 }

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -75,7 +75,7 @@ test-perlbrew-uninstall() {
 test-perlbrew-available() {
     assert-file-exists $PERLBREW
     assert-ok $PERLBREW available
-    assert-ok "$PERLBREW available | grep 'perl-5.40.2'"
+    assert-ok "$PERLBREW available | grep 'perl-5.42'"
 }
 
 test-perlbrew-install-cpm() {

--- a/test-e2e/run.zsh
+++ b/test-e2e/run.zsh
@@ -28,4 +28,6 @@ else
 
     test-perlbrew-install perl-5.40.2
     test-perlbrew-uninstall perl-5.40.2
+
+    test-perlbrew-install-cpm
 fi


### PR DESCRIPTION
This runs `intsall-cpm` and verify if `cpm` is put in the right place.

It also go through the code where `prompt()` is called and can be used as a test cases for #856 