### PR TITLE
ci: Let e2e tests run macos-{14,15,26}

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,39 @@ jobs:
         perl-version: '5.40'
     - uses: actions/checkout@v4
     - run: zsh ./test-e2e/run.zsh
+  macos-14:
+    runs-on: macos-14
+    env:
+      PERLBREW_E2E: 1
+      PERLBREW_E2E_INSTALL_NOTEST: 1
+    steps:
+    - uses: shogo82148/actions-setup-perl@v1.31.3
+      with:
+        perl-version: '5.40'
+    - uses: actions/checkout@v4
+    - run: zsh ./test-e2e/run.zsh
+  macos-15:
+    runs-on: macos-15
+    env:
+      PERLBREW_E2E: 1
+      PERLBREW_E2E_INSTALL_NOTEST: 1
+    steps:
+    - uses: shogo82148/actions-setup-perl@v1.31.3
+      with:
+        perl-version: '5.40'
+    - uses: actions/checkout@v4
+    - run: zsh ./test-e2e/run.zsh
+  macos-26:
+    runs-on: macos-26
+    env:
+      PERLBREW_E2E: 1
+      PERLBREW_E2E_INSTALL_NOTEST: 1
+    steps:
+    - uses: shogo82148/actions-setup-perl@v1.31.3
+      with:
+        perl-version: '5.40'
+    - uses: actions/checkout@v4
+    - run: zsh ./test-e2e/run.zsh
   cygwin:
     runs-on: windows-latest
     env:

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -109,4 +109,7 @@ jobs:
   opensuse:: gen-container-job(job-config.opensuse 'opensuse/tumbleweed:latest')
   macos-latest:: gen-macos-job("macos-latest")
   macos-13:: gen-macos-job("macos-13")
+  macos-14:: gen-macos-job("macos-14")
+  macos-15:: gen-macos-job("macos-15")
+  macos-26:: gen-macos-job("macos-26")
   cygwin:: gen-cygwin-job()


### PR DESCRIPTION
https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job?versionId=free-pro-team%40latest&productId=actions&restPage=reference%2Crunners%2Clarger-runners

macos-13 is intel. macos-{14,15,26} are arm.

