### PR TITLE
if git-describe fails to find anything, fallback on --as with sensible defaults

### DIFF
--- a/lib/App/perlbrew.pm
+++ b/lib/App/perlbrew.pm
@@ -1101,6 +1101,14 @@ sub do_install_git {
 
     chdir $cwd_orig;
 
+    unless ( $dist_version ) {
+        die "Unable to determine Perl version from 'git describe'. "
+          . "Please use --as to specify an installation name.\n"
+          unless $self->{as};
+        $dist_name    = 'perl';
+        $dist_version = 'git';
+    }
+
     require File::Spec;
     my $dist_extracted_dir = File::Spec->rel2abs($dist);
     $self->do_install_this( App::Perlbrew::Path->new($dist_extracted_dir), $dist_version, "$dist_name-$dist_version" );

--- a/t/command-install-git.t
+++ b/t/command-install-git.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+use Test2::V0;
+use Test2::Tools::Spec;
+
+use FindBin;
+use lib $FindBin::Bin;
+use App::perlbrew;
+require 'test2_helpers.pl';
+
+describe "do_install_git" => sub {
+    # A real (but empty) git repo: 'git describe' will fail to produce
+    # any output matching the v5.x.x pattern, exercising the new fallback logic.
+    my $checkout;
+
+    before_all 'create git checkout' => sub {
+        $checkout = tempdir(CLEANUP => 1);
+        system("git", "-C", $checkout, "init", "--quiet") == 0
+            or die "Failed to create test git repo\n";
+    };
+
+    it "dies with a helpful message when git describe gives no matching version and --as is not given" => sub {
+        my $app = App::perlbrew->new('install', $checkout);
+        like(
+            dies { $app->do_install_git($checkout) },
+            qr/Unable to determine Perl version from 'git describe'/,
+        );
+    };
+
+    it "calls do_install_this with version 'git' when git describe gives no matching version and --as is given" => sub {
+        my $app = App::perlbrew->new('install', $checkout, '--as', 'my-dev-perl');
+
+        my ($captured_version, $captured_name);
+        my $mock = mocked($app);
+        $mock->expects('do_install_this')->returns(sub {
+            my ($self, $path, $version, $name) = @_;
+            $captured_version = $version;
+            $captured_name    = $name;
+        });
+
+        $app->do_install_git($checkout);
+        $mock->verify;
+
+        is $captured_version, 'git',      'dist_version is "git" so that usedevel is added to configure flags';
+        is $captured_name,    'perl-git',  'installation_name passed to do_install_this is "perl-git"';
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Hey @gugod I have a very small little patch for you, I hope you like it :)

The issue was an interaction between --as and install with a perl5 checkout. Perlbrew looks for output from git-describe in a very specific tag format. If it does not find this tag, it emits a bunch of undef warnings and ends up installing the perl as `-` in perlbrew. 

This patch addresses that by checking to see if anything came back from git-describe and if not, provides sensible defaults that should work with --as. 

I also added a test, it relies on git being on your system, but so does the feature, so I figured it was okay. Let me know if you would prefer I do it differently. 

I was unsure about adding documentation about this, it is a very niche feature, but if you would like I can add that as well. 

Thanks, 

- Stevan