### PR TITLE
improvements of system arch detection on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,10 @@ jobs:
     name: cpanm-dist-system-perl-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Env
-        run: |
-          which perl
-          perl -V:myarchname
-          perl -V
+      - run: which perl
+      - run: |
+          perl -V:osname -V:archname -V:myarchname
+      - run: perl -V
       - name: Install cpanm
         run: |
           curl -L https://cpanmin.us/ -o cpanm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.version }}
+      - run: which perl
+      - run: |
+          perl -V:osname -V:archname -V:myarchname
+      - run: |
+          uname -m
+          uname -a
+      - run: |
+          perl -E 'say $^X'
+      - run: perl -V
       - uses: actions/download-artifact@v4
         with:
           name: App-perlbrew-distdir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,20 @@ jobs:
     name: cpanm-dist-system-perl-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - run: |
+      - name: Env
+        run: |
           which perl
           perl -V:myarchname
           perl -V
-      - run: |
-          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - name: Install cpanm
+        run: |
+          curl -L https://cpanmin.us/ -o cpanm
+          chmod +x cpanm
       - uses: actions/download-artifact@v4
         with:
           name: App-perlbrew-distdir
       - run: echo ./App-perlbrew-*
-      - run: cpanm --verbose ./App-perlbrew-*
+      - run: ./cpanm -L local/ --verbose ./App-perlbrew-*
 
   cpanm-dist-in-container:
     needs: mbtiny-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,22 @@ jobs:
       - run: echo ./App-perlbrew-*
       - run: cpanm --verbose ./App-perlbrew-*
 
+  cpanm-dist-system-perl:
+    needs: mbtiny-dist
+    strategy:
+      matrix:
+        os: ["macos-26-intel", "macos-26"]
+    name: cpanm-dist-system-perl-${{ matrix.os }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - uses: actions/download-artifact@v4
+        with:
+          name: App-perlbrew-distdir
+      - run: echo ./App-perlbrew-*
+      - run: cpanm --verbose ./App-perlbrew-*
+
   cpanm-dist-in-container:
     needs: mbtiny-dist
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     needs: mbtiny-dist
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-26-intel", "macos-latest", "macos-13"]
+        os: ["ubuntu-latest", "macos-26-intel", "macos-26", "macos-15-intel", "macos-15"]
         version: ["5.42","5.40","5.38","5.36","5.34","5.18"]
     name: cpanm-dist-perl-${{ matrix.version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     needs: mbtiny-dist
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "macos-13"]
+        os: ["ubuntu-latest", "macos-26-intel", "macos-latest", "macos-13"]
         version: ["5.42","5.40","5.38","5.36","5.34","5.18"]
     name: cpanm-dist-perl-${{ matrix.version }}-${{ matrix.os }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           perl -V:osname -V:archname -V:myarchname
       - run: |
           uname -m
+          uname -s
           uname -a
       - run: |
           perl -E 'say $^X'
@@ -59,6 +60,7 @@ jobs:
           perl -V:osname -V:archname -V:myarchname
       - run: |
           uname -m
+          uname -s
           uname -a
       - run: |
           perl -E 'say $^X'
@@ -98,6 +100,15 @@ jobs:
         with:
           packages: bash curl make perl gcc-g++ libcrypt-devel perl-Module-Build perl-Module-Pluggable
           add-to-path: true
+      - run: which perl
+      - run: |
+          perl -V:osname -V:archname -V:myarchname
+      - run: |
+          uname -m
+          uname -s
+          uname -a
+      - run: |
+          perl -E 'say $^X'
       - run: |
           curl https://cpanmin.us/ -o ./cpanm
           chmod +x cpanm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
     name: cpanm-dist-system-perl-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
+      - run: brew unlink perl
       - run: which perl
       - run: |
           perl -V:osname -V:archname -V:myarchname

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
+          which perl
+          perl -V
+      - run: |
           curl -L https://cpanmin.us | perl - --sudo App::cpanminus
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - run: which perl
       - run: |
           perl -V:osname -V:archname -V:myarchname
+      - run: |
+          uname -m
+          uname -a
       - run: perl -V
       - name: Install cpanm
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       - run: |
           uname -m
           uname -a
+      - run: |
+          perl -E 'say $^X'
       - run: perl -V
       - name: Install cpanm
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
     steps:
       - run: |
           which perl
+          perl -V:myarchname
           perl -V
       - run: |
           curl -L https://cpanmin.us | perl - --sudo App::cpanminus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         os: ["ubuntu-latest", "macos-26-intel", "macos-latest", "macos-13"]
         version: ["5.42","5.40","5.38","5.36","5.34","5.18"]
     name: cpanm-dist-perl-${{ matrix.version }}-${{ matrix.os }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: shogo82148/actions-setup-perl@v1
         with:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         os: ["macos-26-intel", "macos-26"]
     name: cpanm-dist-system-perl-${{ matrix.os }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - run: |
           which perl

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -414,6 +414,40 @@ jobs:
         fi
     - uses: actions/checkout@v6
     - run: zsh ./test-e2e/run.zsh
+  macos-26-intel:
+    runs-on: macos-26-intel
+    env:
+      PERLBREW_E2E: 1
+      PERLBREW_E2E_INSTALL_NOTEST: 1
+    steps:
+    - name: print system info
+      shell: bash
+      run: |
+        echo "# env"
+        env
+        echo
+        echo "# which perl"
+        which perl
+        echo
+        echo "# perl -V"
+        perl -V
+        echo
+        echo "# perl -MConfig -V:myarchname"
+        perl -MConfig -V:myarchname
+        echo
+        if [[ (-x /usr/bin/perl) && ("$(which perl)" != "/usr/bin/perl") ]]
+        then
+            echo "# /usr/bin/perl -V"
+            /usr/bin/perl -V
+            echo
+            echo "# /usr/bin/perl -MConfig -V:myarchname"
+            /usr/bin/perl -MConfig -V:myarchname
+            echo
+        else
+            true
+        fi
+    - uses: actions/checkout@v6
+    - run: zsh ./test-e2e/run.zsh
   cygwin:
     runs-on: windows-latest
     env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -69,6 +72,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -106,6 +112,9 @@ jobs:
       run: |
         echo "# env"
         env
+        echo
+        echo "# uname -m"
+        uname -m
         echo
         echo "# which perl"
         which perl
@@ -145,6 +154,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -182,6 +194,9 @@ jobs:
       run: |
         echo "# env"
         env
+        echo
+        echo "# uname -m"
+        uname -m
         echo
         echo "# which perl"
         which perl
@@ -222,6 +237,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -255,6 +273,9 @@ jobs:
       run: |
         echo "# env"
         env
+        echo
+        echo "# uname -m"
+        uname -m
         echo
         echo "# which perl"
         which perl
@@ -290,6 +311,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -323,6 +347,9 @@ jobs:
       run: |
         echo "# env"
         env
+        echo
+        echo "# uname -m"
+        uname -m
         echo
         echo "# which perl"
         which perl
@@ -358,6 +385,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -392,6 +422,9 @@ jobs:
         echo "# env"
         env
         echo
+        echo "# uname -m"
+        uname -m
+        echo
         echo "# which perl"
         which perl
         echo
@@ -425,6 +458,9 @@ jobs:
       run: |
         echo "# env"
         env
+        echo
+        echo "# uname -m"
+        uname -m
         echo
         echo "# which perl"
         which perl

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,6 @@ jobs:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
-        yes | unminimize
         apt-get update -y
         apt-get install -y zsh perl curl build-essential man-db
     - name: print system info

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -54,6 +54,9 @@ e2e-steps =::
       echo "# env"
       env
       echo
+      echo "# uname -m"
+      uname -m
+      echo
       echo "# which perl"
       which perl
       echo

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -140,4 +140,5 @@ jobs:
   macos-14:: gen-macos-job("macos-14")
   macos-15:: gen-macos-job("macos-15")
   macos-26:: gen-macos-job("macos-26")
+  macos-26-intel:: gen-macos-job("macos-26-intel")
   cygwin:: gen-cygwin-job()

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -30,7 +30,6 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
-      yes | unminimize
       apt-get update -y
       apt-get install -y zsh perl curl build-essential man-db
   

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -2,7 +2,6 @@ package App::Perlbrew::Sys;
 use strict;
 use warnings;
 use Config;
-use Capture::Tiny qw(capture);
 
 sub osname {
     $Config{osname}

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -17,7 +17,7 @@ sub os {
 }
 
 sub _uname_m {
-    my $uname = qx(uname -m 2 >/dev/null);
+    my $uname = qx(uname -m 2>/dev/null);
     chomp($uname);
     return $uname;
 }

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -22,10 +22,15 @@ sub perlpath {
     return $Config{perlpath} . ( $Config{perlpath} =~ m/$Config{_exe}$/i ? "" : $Config{_exe} );
 }
 
+sub _uname_m {
+    my $uname = qw(uname -m 2 >/dev/null);
+    chomp($uname);
+    return $uname;
+}
+
 sub arch {
-    if (os() eq 'darwin' && perlpath() eq "/usr/bin/perl") {
-        my $output = qx(uname -m);
-        return $output;
+    if (os() eq 'darwin') {
+        return _uname_m();
     } else {
         return (split(/-/, $Config{myarchname}, 2))[0];
     }

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -16,13 +16,18 @@ sub os {
     $Config{osname}
 }
 
+sub perlpath {
+    # Ref: perldoc: perlvar. On $EXECUTABLE_NAME / $^X
+    # https://perldoc.perl.org/perlvar#$%5EX
+    return $Config{perlpath} . ( $Config{perlpath} =~ m/$Config{_exe}$/i ? "" : $Config{_exe} );
+}
+
 sub arch {
-    print STDERR "DEBUG Sys: " . os() . " " . $^X . "\n";
-    if (os() eq 'darwin' && $^X eq '/usr/bin/perl') {
+    if (os() eq 'darwin' && perlpath() eq "/usr/bin/perl") {
         my $output = qx(uname -m);
         return $output;
     } else {
-        return (split(/-/, $Config{myarchname}, 2))[0]
+        return (split(/-/, $Config{myarchname}, 2))[0];
     }
 }
 

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -2,6 +2,7 @@ package App::Perlbrew::Sys;
 use strict;
 use warnings;
 use Config;
+use Capture::Tiny qw(capture);
 
 sub osname {
     $Config{osname}
@@ -16,7 +17,12 @@ sub os {
 }
 
 sub arch {
-    (split(/-/, $Config{myarchname}, 2))[0]
+    if (os() eq 'darwin' && $^X eq '/usr/bin/perl') {
+        my $output = qx(uname -m);
+        return $output;
+    } else {
+        return (split(/-/, $Config{myarchname}, 2))[0]
+    }
 }
 
 1;

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -16,12 +16,6 @@ sub os {
     $Config{osname}
 }
 
-sub perlpath {
-    # Ref: perldoc: perlvar. On $EXECUTABLE_NAME / $^X
-    # https://perldoc.perl.org/perlvar#$%5EX
-    return $Config{perlpath} . ( $Config{perlpath} =~ m/$Config{_exe}$/i ? "" : $Config{_exe} );
-}
-
 sub _uname_m {
     my $uname = qx(uname -m 2 >/dev/null);
     chomp($uname);

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -17,6 +17,7 @@ sub os {
 }
 
 sub arch {
+    print STDERR "DEBUG Sys: " . os() . " " . $^X . "\n";
     if (os() eq 'darwin' && $^X eq '/usr/bin/perl') {
         my $output = qx(uname -m);
         return $output;

--- a/lib/App/Perlbrew/Sys.pm
+++ b/lib/App/Perlbrew/Sys.pm
@@ -23,7 +23,7 @@ sub perlpath {
 }
 
 sub _uname_m {
-    my $uname = qw(uname -m 2 >/dev/null);
+    my $uname = qx(uname -m 2 >/dev/null);
     chomp($uname);
     return $uname;
 }

--- a/lib/App/Perlbrew/Util.pm
+++ b/lib/App/Perlbrew/Util.pm
@@ -141,11 +141,31 @@ sub looks_like_sys_would_be_compatible_with_skaji_relocatable_perl {
 
 sub make_skaji_relocatable_perl_url {
     my ($str, $sys) = @_;
+    # The downloadable distributions can be explored at the page of Release:
+    # https://github.com/skaji/relocatable-perl/releases
+
     if ($str =~ m/\Askaji-relocatable-perl-(5\.[0-9][0-9]\.[0-9][0-9]?.[0-9])\z/) {
         my $version = $1;
+
+        # Eath of these 2 on-URL terms has 2 variants.
+        #
+        #   OS is either 'darwin' or 'linux'
+        #   Arch is either 'arm64' or 'amd64'
+        #
+        # In here we map all our detected value to those 4 values.  If
+        # we encounter anything we do not recognize, then we return
+        # undef, meaning that there are no corresponding distribution
+        # of skaji-relocatable-perl for this system.
+
         my $os = $sys->os;
-        my $arch = $sys->arch;
-        $arch = "amd64" if $arch eq 'x86_64' || $arch eq 'i386';
+
+        my $arch = {
+            'i386' => 'amd64',
+            'x86_64' => 'amd64',
+            'arm64' => 'arm64',
+        }->{$sys->arch};
+
+        return undef unless defined($os) && defined($arch);
 
         return "https://github.com/skaji/relocatable-perl/releases/download/$version/perl-$os-$arch.tar.gz";
     }

--- a/lib/App/Perlbrew/Util.pm
+++ b/lib/App/Perlbrew/Util.pm
@@ -157,7 +157,11 @@ sub make_skaji_relocatable_perl_url {
         # undef, meaning that there are no corresponding distribution
         # of skaji-relocatable-perl for this system.
 
-        my $os = $sys->os;
+        my $os = {
+            'darwin' => 'darwin',
+            'linux' => 'linux',
+            'cygwin' => undef,
+        }->{$sys->os};
 
         my $arch = {
             'i386' => 'amd64',

--- a/t/sys.t
+++ b/t/sys.t
@@ -19,7 +19,7 @@ subtest 'sys', sub {
             };
             $arch_by_uname =~ s/\n$//;
 
-            is $o->sys->archname(), $arch_by_uname, "archname: should match the output of `uname -m`.";
+            is $o->sys->arch(), $arch_by_uname, "archname: should match the output of `uname -m`.";
         };
     }
 };

--- a/t/sys.t
+++ b/t/sys.t
@@ -1,6 +1,7 @@
 use Test2::V0;
 
 use App::perlbrew;
+use Capture::Tiny qw(capture_stdout);
 
 subtest 'sys', sub {
     my $o = App::perlbrew->new();
@@ -9,6 +10,18 @@ subtest 'sys', sub {
     is $o->sys->arch(), D();
     is $o->sys->osname(), D();
     is $o->sys->archname(), D();
+
+    if ($o->sys->os() eq 'darwin') {
+        subtest 'macOS', sub {
+            my $arch_by_uname = capture_stdout {
+                system("uname", "-m") == 0
+                    or die "system() failed: uname -m. Error: $!";
+            };
+            $arch_by_uname =~ s/\n$//;
+
+            is $o->sys->archname(), $arch_by_uname, "archname: should match the output of `uname -m`.";
+        };
+    }
 };
 
 done_testing;

--- a/t/util-make-skaji-relocatable-perl-url.t
+++ b/t/util-make-skaji-relocatable-perl-url.t
@@ -1,0 +1,52 @@
+use Test2::V0;
+use App::Perlbrew::Sys;
+use App::Perlbrew::Util qw(make_skaji_relocatable_perl_url);
+
+subtest 'make_skaji_relocatable_perl_url', sub {
+    my $expected_os;
+    my $expected_arch;
+
+    if ($ENV{CI} && $ENV{GITHUB_ACTION} && $ENV{RUNNER_OS}) {
+        if ($ENV{RUNNER_OS} eq "macOS" && $ENV{RUNNER_ARCH}) {
+            # Possible value fo RUNNER_ARCH are: X86, X64, ARM, or ARM64.
+            # Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+            $expected_os = "darwin";
+            $expected_arch = {
+                "X86" => "amd64",
+                "X64" => "amd64",
+                "ARM" => "arm64",
+                "ARM64" => "arm64",
+            }->{$ENV{RUNNER_ARCH}};
+        }
+    }
+
+    my $url = make_skaji_relocatable_perl_url(
+        "skaji-relocatable-perl-5.42.2.0",
+        'App::Perlbrew::Sys'
+    );
+
+    like(
+        $url,
+        qr(/download/5.42.2.0/perl-
+           (linux|darwin)
+           -
+           (amd64|arm64)
+           \.tar\.gz
+           \z )x,
+        "With a generic pattern.");
+
+    if ($expected_os && $expected_arch) {
+        like(
+            $url,
+            qr(/download/5.42.2.0/perl-
+               \Q${expected_os}\E
+               -
+               \Q${expected_arch}\E
+               \.tar\.gz
+               \z )x,
+            "With exact os and arch");
+    }
+
+};
+
+done_testing;

--- a/t/util-make-skaji-relocatable-perl-url.t
+++ b/t/util-make-skaji-relocatable-perl-url.t
@@ -2,6 +2,8 @@ use Test2::V0;
 use App::Perlbrew::Sys;
 use App::Perlbrew::Util qw(make_skaji_relocatable_perl_url);
 
+my $sys = 'App::Perlbrew::Sys';
+
 subtest 'make_skaji_relocatable_perl_url', sub {
     my $expected_os;
     my $expected_arch;
@@ -22,18 +24,23 @@ subtest 'make_skaji_relocatable_perl_url', sub {
 
     my $url = make_skaji_relocatable_perl_url(
         "skaji-relocatable-perl-5.42.2.0",
-        'App::Perlbrew::Sys'
+        $sys,
     );
 
-    like(
-        $url,
-        qr(/download/5.42.2.0/perl-
-           (linux|darwin)
-           -
-           (amd64|arm64)
-           \.tar\.gz
-           \z )x,
-        "With a generic pattern.");
+
+    if ($sys->os() eq 'cygwin') {
+        is $url, undef;
+    } else {
+        like(
+            $url,
+            qr(/download/5.42.2.0/perl-
+               (linux|darwin)
+               -
+               (amd64|arm64)
+               \.tar\.gz
+               \z )x,
+            "With a generic pattern.");
+    }
 
     if ($expected_os && $expected_arch) {
         like(


### PR DESCRIPTION
Via discussion in #861 we've discovered that macos on Apple Sillicon
comes with /usr/bin/perl with myarchname being x86_64 but not aarch64
and therefore that value cannot be used to determine the actual arch.
