### PR TITLE
ci: require git on cygwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: cygwin/cygwin-install-action@master
         with:
-          packages: bash curl make perl gcc-g++ libcrypt-devel perl-Module-Build perl-Module-Pluggable
+          packages: bash curl make perl gcc-g++ libcrypt-devel perl-Module-Build perl-Module-Pluggable git
           add-to-path: true
       - run: |
           curl https://cpanmin.us/ -o ./cpanm


### PR DESCRIPTION
In the CI runs of PR #870 we see CI failed on cygwin. But that PR wasn't targeting cygwin. Thus the fix goes into this PRo.

https://github.com/gugod/App-perlbrew/actions/runs/26606773273/job/78403727664
