### PR TITLE
e2e: Test `perlbrew use $installation`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -298,43 +298,6 @@ jobs:
         fi
     - uses: actions/checkout@v6
     - run: zsh ./test-e2e/run.zsh
-  macos-13:
-    runs-on: macos-13
-    env:
-      PERLBREW_E2E: 1
-      PERLBREW_E2E_INSTALL_NOTEST: 1
-    steps:
-    - name: print system info
-      shell: bash
-      run: |
-        echo "# env"
-        env
-        echo
-        echo "# uname -m"
-        uname -m
-        echo
-        echo "# which perl"
-        which perl
-        echo
-        echo "# perl -V"
-        perl -V
-        echo
-        echo "# perl -MConfig -V:myarchname"
-        perl -MConfig -V:myarchname
-        echo
-        if [[ (-x /usr/bin/perl) && ("$(which perl)" != "/usr/bin/perl") ]]
-        then
-            echo "# /usr/bin/perl -V"
-            /usr/bin/perl -V
-            echo
-            echo "# /usr/bin/perl -MConfig -V:myarchname"
-            /usr/bin/perl -MConfig -V:myarchname
-            echo
-        else
-            true
-        fi
-    - uses: actions/checkout@v6
-    - run: zsh ./test-e2e/run.zsh
   macos-14:
     runs-on: macos-14
     env:

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -138,7 +138,6 @@ jobs:
   rockylinux:: gen-container-job(job-config.rockylinux 'docker.io/rockylinux/rockylinux:latest')
   opensuse:: gen-container-job(job-config.opensuse 'opensuse/tumbleweed:latest')
   macos-latest:: gen-macos-job("macos-latest")
-  macos-13:: gen-macos-job("macos-13")
   macos-14:: gen-macos-job("macos-14")
   macos-15:: gen-macos-job("macos-15")
   macos-26:: gen-macos-job("macos-26")

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -1,7 +1,6 @@
 PERLBREW_E2E=/tmp/e2e
 export PERLBREW_ROOT=$PERLBREW_E2E/root
 export PERLBREW_HOME=$PERLBREW_E2E/home
-
 PERLBREW=$PERLBREW_ROOT/bin/perlbrew
 
 e2e-begin() {
@@ -55,11 +54,11 @@ test-perlbrew-install() {
 
     echo "OK - perlbrew install $installation"
 
-    if [[ "$CI" ]]; then
+    if [[ -n "$CI" ]]; then
         echo "# CI"
-        (env | grep -E 'RUNNER_(OS|ARCH)') | while read line; do
-            echo "# $line"
-        done
+        (
+            env | grep -E 'RUNNER_(OS|ARCH)'
+        ) | while read line; do echo "# $line"; done
     fi
 }
 
@@ -120,7 +119,7 @@ test-perlbrew-use() {
 
     echo "TEST - perlbrew use $installation"
 
-    if [[ perlbrew list | grep $installation ]]; then
+    if (perlbrew list | grep $installation); then
         echo "OK - installation exist: $installation"
     else
         echo "FAIL - installation exist: $installation"
@@ -131,10 +130,10 @@ test-perlbrew-use() {
         perlbrew use $installation
     ) | while read line; do echo "# $line"; done
 
-    if [[ perlbrew use | grep $installation ]]; then
-        echo "OK - installation is being used'
+    if (perlbrew use | grep $installation); then
+        echo "OK - installation is being used"
     else
-        echo "FAIL - installation is being used'
+        echo "FAIL - installation is being used"
     fi
 
     (

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -54,6 +54,13 @@ test-perlbrew-install() {
     assert-ok $PERLBREW_ROOT/perls/$installation/bin/perl -v
 
     echo "OK - perlbrew install $installation"
+
+    if [[ "$CI" ]]; then
+        echo "# CI"
+        (env | grep -E 'RUNNER_(OS|ARCH)') | while read line; do
+            echo "# $line"
+        done
+    fi
 }
 
 test-perlbrew-uninstall() {
@@ -105,4 +112,31 @@ test-perlbrew-install-cpm() {
     else
         echo "OK - overrided"
     fi
+}
+
+test-perlbrew-use() {
+    local installation=$1
+    shift
+
+    if [[ perlbrew list | grep $installation ]]; then
+        echo "OK - installation exist: $installation"
+    else
+        echo "FAIL - installation exist: $installation"
+    fi
+
+    (
+        perlbrew off
+        perlbrew use $installation
+    ) | while read line; do echo "# $line"; done
+
+    if [[ perlbrew use | grep $installation ]]; then
+        echo "OK - installation is being used'
+    else
+        echo "FAIL - installation is being used'
+    fi
+
+    (
+        which perl
+        perl -V:osname -V:archname -V:myarchname
+    ) | while read line; do echo "# $line"; done
 }

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -126,8 +126,8 @@ test-perlbrew-use() {
     fi
 
     (
-        perlbrew off
         perlbrew use $installation
+        perlbrew use
     ) | while read line; do echo "# $line"; done
 
     if (perlbrew use | grep $installation); then
@@ -137,7 +137,10 @@ test-perlbrew-use() {
     fi
 
     (
+        echo "Verifying the effect of perlbrew use $installation"
         which perl
         perl -V:osname -V:archname -V:myarchname
     ) | while read line; do echo "# $line"; done
+
+    perlbrew off
 }

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -125,10 +125,10 @@ test-perlbrew-use() {
         echo "FAIL - installation exist: $installation"
     fi
 
-    (
-        perlbrew use $installation
-        perlbrew use
-    ) | while read line; do echo "# $line"; done
+    # This line (`perlbrew use ...`) is the target of our test and
+    # cannot be put into a subshell.  Because it should effect env var
+    # in current shell, putting it in a subshell makes it useless.
+    perlbrew use $installation | while read line; do echo "# $line"; done
 
     perlbrew use | read line
 
@@ -150,9 +150,11 @@ test-perlbrew-use() {
         which perl
         perl -V:osname -V:archname -V:myarchname
 
-        echo "# Turning perlbrew off"
-        perlbrew off
     ) | while read line; do echo "# $line"; done
 
-
+    # Similarly, `perlbrew off` is meant to effect current shell, not
+    # subshells, and thus cannot be put into a subshell.
+    echo "# # Turning perlbrew off"
+    echo -n "# ";
+    perlbrew off
 }

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -117,7 +117,6 @@ test-perlbrew-use() {
     local installation=$1
     shift
 
-    echo "TEST - perlbrew use $installation"
 
     if (perlbrew list | grep $installation >/dev/null); then
         echo "OK - installation exist: $installation"
@@ -125,11 +124,13 @@ test-perlbrew-use() {
         echo "FAIL - installation exist: $installation"
     fi
 
+    echo "TEST - perlbrew use $installation"
     # This line (`perlbrew use ...`) is the target of our test and
     # cannot be put into a subshell.  Because it should effect env var
     # in current shell, putting it in a subshell makes it useless.
     perlbrew use $installation | while read line; do echo "# $line"; done
 
+    echo "# perlbrew use =>"
     perlbrew use | read line
 
     if [[ "$line" == "Currently using $installation" ]]; then

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -119,7 +119,7 @@ test-perlbrew-use() {
 
     echo "TEST - perlbrew use $installation"
 
-    if (perlbrew list | grep $installation); then
+    if (perlbrew list | grep $installation >/dev/null); then
         echo "OK - installation exist: $installation"
     else
         echo "FAIL - installation exist: $installation"
@@ -130,19 +130,29 @@ test-perlbrew-use() {
         perlbrew use
     ) | while read line; do echo "# $line"; done
 
-    if (perlbrew use | grep $installation); then
+    perlbrew use | read line
+
+    if [[ "$line" == "Currently using $installation" ]]; then
         echo "OK - installation is being used"
     else
         echo "FAIL - installation is being used"
     fi
 
     (
-        echo "Verifying the effect of perlbrew use $installation"
+        echo "# Verifying the effect of perlbrew use $installation"
         type perlbrew
         perlbrew info
+
+        echo "# List of installations we have"
+        perlbrew list
+
+        echo "# inspecting info of current perl"
         which perl
         perl -V:osname -V:archname -V:myarchname
+
+        echo "# Turning perlbrew off"
+        perlbrew off
     ) | while read line; do echo "# $line"; done
 
-    perlbrew off
+
 }

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -122,6 +122,7 @@ test-perlbrew-use() {
         echo "OK - installation exist: $installation"
     else
         echo "FAIL - installation exist: $installation"
+        exit 1
     fi
 
     echo "TEST - perlbrew use $installation"
@@ -137,6 +138,7 @@ test-perlbrew-use() {
         echo "OK - installation is being used"
     else
         echo "FAIL - installation is being used"
+        exit 1
     fi
 
     (

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -138,6 +138,8 @@ test-perlbrew-use() {
 
     (
         echo "Verifying the effect of perlbrew use $installation"
+        type perlbrew
+        perlbrew info
         which perl
         perl -V:osname -V:archname -V:myarchname
     ) | while read line; do echo "# $line"; done

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -118,6 +118,8 @@ test-perlbrew-use() {
     local installation=$1
     shift
 
+    echo "TEST - perlbrew use $installation"
+
     if [[ perlbrew list | grep $installation ]]; then
         echo "OK - installation exist: $installation"
     else

--- a/test-e2e/lib-tests.zsh
+++ b/test-e2e/lib-tests.zsh
@@ -128,10 +128,10 @@ test-perlbrew-use() {
     # This line (`perlbrew use ...`) is the target of our test and
     # cannot be put into a subshell.  Because it should effect env var
     # in current shell, putting it in a subshell makes it useless.
-    perlbrew use $installation | while read line; do echo "# $line"; done
+    perlbrew use $installation
 
-    echo "# perlbrew use =>"
     perlbrew use | read line
+    echo "# perlbrew use => [$line]"
 
     if [[ "$line" == "Currently using $installation" ]]; then
         echo "OK - installation is being used"

--- a/test-e2e/run.zsh
+++ b/test-e2e/run.zsh
@@ -34,9 +34,9 @@ else
     test-perlbrew-use perl-5.40.3
 
     test-perlbrew-install perl-5.42.0
-    test-perlbrew-use perl-5.42.3
+    test-perlbrew-use perl-5.42.0
     test-perlbrew-use perl-5.40.3
-    test-perlbrew-use perl-5.42.3
+    test-perlbrew-use perl-5.42.0
 
     test-perlbrew-uninstall perl-5.40.3
     test-perlbrew-uninstall perl-5.42.0

--- a/test-e2e/run.zsh
+++ b/test-e2e/run.zsh
@@ -20,15 +20,25 @@ else
     test-perlbrew-available
 
     if [[ ! ( "$OSTYPE" =~ ^cygwin ) ]]; then
-        test-perlbrew-install skaji-relocatable-perl-5.40.2.1
-        test-perlbrew-uninstall skaji-relocatable-perl-5.40.2.1
-        test-perlbrew-install skaji-relocatable-perl-5.42.0.0
-        test-perlbrew-uninstall skaji-relocatable-perl-5.42.0.0
+        test-perlbrew-install skaji-relocatable-perl-5.42.1.0
+        test-perlbrew-install skaji-relocatable-perl-5.42.2.0
+
+        test-perlbrew-use skaji-relocatable-perl-5.42.1.0
+        test-perlbrew-use skaji-relocatable-perl-5.42.2.0
+
+        test-perlbrew-uninstall skaji-relocatable-perl-5.42.1.0
+        test-perlbrew-uninstall skaji-relocatable-perl-5.42.2.0
     fi
 
     test-perlbrew-install perl-5.40.3
-    test-perlbrew-uninstall perl-5.40.3
+    test-perlbrew-use perl-5.40.3
+
     test-perlbrew-install perl-5.42.0
+    test-perlbrew-use perl-5.42.3
+    test-perlbrew-use perl-5.40.3
+    test-perlbrew-use perl-5.42.3
+
+    test-perlbrew-uninstall perl-5.40.3
     test-perlbrew-uninstall perl-5.42.0
 
     test-perlbrew-install-cpm


### PR DESCRIPTION
This PR extend e2e tests to do some brief assertions on `perlbrew use`
and also print env info, including github runner env vars RUNNER_OS
and RUNNER_ARCH, as well as the Config vars used in Sys.pm

The purpose is so that we could inspect if Sys.pm is indeed correctly detecting system information.

Consider this as a verification step of #861 and #817.
