### PR TITLE
remove "macos-latest" from CI (duplicate of macos-26)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -261,43 +261,6 @@ jobs:
         fi
     - uses: actions/checkout@v6
     - run: zsh ./test-e2e/run.zsh
-  macos-latest:
-    runs-on: macos-latest
-    env:
-      PERLBREW_E2E: 1
-      PERLBREW_E2E_INSTALL_NOTEST: 1
-    steps:
-    - name: print system info
-      shell: bash
-      run: |
-        echo "# env"
-        env
-        echo
-        echo "# uname -m"
-        uname -m
-        echo
-        echo "# which perl"
-        which perl
-        echo
-        echo "# perl -V"
-        perl -V
-        echo
-        echo "# perl -MConfig -V:myarchname"
-        perl -MConfig -V:myarchname
-        echo
-        if [[ (-x /usr/bin/perl) && ("$(which perl)" != "/usr/bin/perl") ]]
-        then
-            echo "# /usr/bin/perl -V"
-            /usr/bin/perl -V
-            echo
-            echo "# /usr/bin/perl -MConfig -V:myarchname"
-            /usr/bin/perl -MConfig -V:myarchname
-            echo
-        else
-            true
-        fi
-    - uses: actions/checkout@v6
-    - run: zsh ./test-e2e/run.zsh
   macos-14:
     runs-on: macos-14
     env:

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -137,7 +137,6 @@ jobs:
   almalinux:: gen-container-job(job-config.almalinux 'almalinux:latest')
   rockylinux:: gen-container-job(job-config.rockylinux 'docker.io/rockylinux/rockylinux:latest')
   opensuse:: gen-container-job(job-config.opensuse 'opensuse/tumbleweed:latest')
-  macos-latest:: gen-macos-job("macos-latest")
   macos-14:: gen-macos-job("macos-14")
   macos-15:: gen-macos-job("macos-15")
   macos-26:: gen-macos-job("macos-26")


### PR DESCRIPTION
Since I do wish to know at least what major version it is. macos-26 is better than macos-latest.
