### PR TITLE
ci: opensuse: deal with the errors related to dependency resolution on `devel_basis`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -222,12 +222,13 @@ jobs:
   opensuse:
     runs-on: ubuntu-latest
     container:
-      image: opensuse/leap:latest
+      image: opensuse/tumbleweed:latest
     env:
       PERLBREW_E2E: 1
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
+        zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
         zypper --non-interactive install -t pattern devel_basis
         zypper --non-interactive install zsh perl awk which
     - name: print system info

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -222,13 +222,12 @@ jobs:
   opensuse:
     runs-on: ubuntu-latest
     container:
-      image: opensuse/tumbleweed:latest
+      image: opensuse/leap:latest
     env:
       PERLBREW_E2E: 1
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
-        zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
         zypper --non-interactive install -t pattern devel_basis
         zypper --non-interactive install zsh perl awk which
     - name: print system info

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,8 +228,8 @@ jobs:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
-        zypper install -y -t pattern devel_basis
-        zypper install -y zsh perl awk which
+        zypper --non-interactive install -t pattern devel_basis
+        zypper --non-interactive install zsh perl awk which
     - name: print system info
       shell: bash
       run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,7 +228,7 @@ jobs:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
-        zypper --non-interactive install 'libncurses6<6.6.20260530'
+        zypper --non-interactive refresh --force
         zypper --non-interactive install -t pattern devel_basis
         zypper --non-interactive install zsh perl awk which
     - name: print system info

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,7 +228,7 @@ jobs:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
-        zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
+        zypper --non-interactive install libncurses6=6.6.20260516-105.1
         zypper --non-interactive install -t pattern devel_basis
         zypper --non-interactive install zsh perl awk which
     - name: print system info

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,7 +228,7 @@ jobs:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
-        zypper --non-interactive install libncurses6=6.6.20260516-105.1
+        zypper --non-interactive install 'libncurses6<6.6.20260530'
         zypper --non-interactive install -t pattern devel_basis
         zypper --non-interactive install zsh perl awk which
     - name: print system info

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,6 +228,7 @@ jobs:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     steps:
     - run: |
+        zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
         zypper --non-interactive install -t pattern devel_basis
         zypper --non-interactive install zsh perl awk which
     - name: print system info

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,7 +37,7 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
-      zypper --non-interactive install libncurses6=6.6.20260516-105.1
+      zypper --non-interactive install 'libncurses6<6.6.20260530'
       zypper --non-interactive install -t pattern devel_basis
       zypper --non-interactive install zsh perl awk which
   

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,6 +37,7 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
+      zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
       zypper --non-interactive install -t pattern devel_basis
       zypper --non-interactive install zsh perl awk which
   
@@ -136,7 +137,7 @@ jobs:
   fedora:: gen-container-job(job-config.fedora 'fedora:latest')
   almalinux:: gen-container-job(job-config.almalinux 'almalinux:latest')
   rockylinux:: gen-container-job(job-config.rockylinux 'docker.io/rockylinux/rockylinux:latest')
-  opensuse:: gen-container-job(job-config.opensuse 'opensuse/leap:latest')
+  opensuse:: gen-container-job(job-config.opensuse 'opensuse/tumbleweed:latest')
   macos-14:: gen-macos-job("macos-14")
   macos-15:: gen-macos-job("macos-15")
   macos-26:: gen-macos-job("macos-26")

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,7 +37,7 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
-      zypper --non-interactive install 'libncurses6<6.6.20260530'
+      zypper --non-interactive refresh --force
       zypper --non-interactive install -t pattern devel_basis
       zypper --non-interactive install zsh perl awk which
   

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,7 +37,7 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
-      zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
+      zypper --non-interactive install libncurses6=6.6.20260516-105.1
       zypper --non-interactive install -t pattern devel_basis
       zypper --non-interactive install zsh perl awk which
   

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,7 +37,6 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
-      zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
       zypper --non-interactive install -t pattern devel_basis
       zypper --non-interactive install zsh perl awk which
   
@@ -137,7 +136,7 @@ jobs:
   fedora:: gen-container-job(job-config.fedora 'fedora:latest')
   almalinux:: gen-container-job(job-config.almalinux 'almalinux:latest')
   rockylinux:: gen-container-job(job-config.rockylinux 'docker.io/rockylinux/rockylinux:latest')
-  opensuse:: gen-container-job(job-config.opensuse 'opensuse/tumbleweed:latest')
+  opensuse:: gen-container-job(job-config.opensuse 'opensuse/leap:latest')
   macos-14:: gen-macos-job("macos-14")
   macos-15:: gen-macos-job("macos-15")
   macos-26:: gen-macos-job("macos-26")

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,6 +37,7 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
+      zypper --non-interactive install libncurses6-6.6.20260516-105.1.x86_64
       zypper --non-interactive install -t pattern devel_basis
       zypper --non-interactive install zsh perl awk which
   

--- a/.github/workflows/e2e.ys
+++ b/.github/workflows/e2e.ys
@@ -37,8 +37,8 @@ job-config =::
     env:
       PERLBREW_E2E_INSTALL_NOTEST: 1
     init: |
-      zypper install -y -t pattern devel_basis
-      zypper install -y zsh perl awk which
+      zypper --non-interactive install -t pattern devel_basis
+      zypper --non-interactive install zsh perl awk which
   
   alpine:
     env:


### PR DESCRIPTION
We see some depencey resolution errors like this:

   Problem: 1: the to be installed pattern:devel_basis-20170319-13.3.x86_64 requires 'patterns-devel-base-devel_basis', but this requirement cannot be provided
   not installable providers: patterns-devel-base-devel_basis-20170319-13.3.x86_64[repo-oss]

==> https://github.com/gugod/App-perlbrew/actions/runs/26993763083/job/79659184194?pr=875

zypper suggest 3 solutions and prompt user for making a decision. Since the user is always AFK (?), adding `--non-interactive-` flag to make it pick (supposedly) the 1st solution makes sense.

Here's some references about this flag:

- https://manpages.opensuse.org/Tumbleweed/zypper/zypper.8.en.html#GLOBAL_OPTIONS:~:text=%2Dn%2C%20%2D%2Dnon%2Dinteractive
- https://unix.stackexchange.com/questions/82016/how-to-use-zypper-in-bash-scripts-for-someone-coming-from-apt-get#338314

`--non-interactive` is a "Global Option" and that seems to replac `-y`, at least judging from the description.